### PR TITLE
feat: define error handling strategy with custom error hierarchy (#19)

### DIFF
--- a/src/adapters/BaseContractWrapper.ts
+++ b/src/adapters/BaseContractWrapper.ts
@@ -7,7 +7,7 @@ import {
   xdr,
   Keypair,
 } from "@stellar/stellar-sdk";
-import { ContractExecutionError, mapRpcError } from "../errors";
+import { ContractExecutionError, ContractErrorCode, mapRpcError } from "../errors";
 
 /** How long (ms) to wait between transaction status polls */
 const POLL_INTERVAL_MS = 2_000;
@@ -72,7 +72,7 @@ export abstract class BaseContractWrapper {
       if (rpc.Api.isSimulationError(simResult)) {
         throw new ContractExecutionError(
           `Simulation failed for "${method}": ${simResult.error}`,
-          1001 // ContractErrorCode.SIMULATION_FAILED
+          ContractErrorCode.SIMULATION_FAILED
         );
       }
 
@@ -89,7 +89,7 @@ export abstract class BaseContractWrapper {
           `Transaction submission failed for "${method}": ${JSON.stringify(
             sendResult.errorResult
           )}`,
-          1002 // ContractErrorCode.TRANSACTION_SUBMISSION_FAILED
+          ContractErrorCode.TRANSACTION_SUBMISSION_FAILED
         );
       }
 
@@ -125,7 +125,7 @@ export abstract class BaseContractWrapper {
       if (statusResult.status === rpc.Api.GetTransactionStatus.FAILED) {
         throw new ContractExecutionError(
           `Contract reverted during "${method}": ${JSON.stringify(statusResult.resultMetaXdr)}`,
-          1005 // ContractErrorCode.CONTRACT_REVERT
+          ContractErrorCode.CONTRACT_REVERT
         );
       }
 
@@ -134,7 +134,7 @@ export abstract class BaseContractWrapper {
 
     throw new ContractExecutionError(
       `Transaction timed out after ${MAX_POLLS} polls for "${method}" (hash: ${txHash})`,
-      1003 // ContractErrorCode.TRANSACTION_TIMEOUT
+      ContractErrorCode.TRANSACTION_TIMEOUT
     );
   }
 }

--- a/src/core/errors.ts
+++ b/src/core/errors.ts
@@ -1,0 +1,167 @@
+/**
+ * Context metadata attached to SDK errors for debugging.
+ */
+export interface ErrorContext {
+  /** Transaction hash related to the error */
+  transactionId?: string;
+  /** Contract ID involved */
+  contractId?: string;
+  /** Network (testnet/mainnet) */
+  network?: string;
+  /** Arbitrary additional context */
+  [key: string]: unknown;
+}
+
+// ── Base Error ──────────────────────────────────────────────────────────────
+
+/**
+ * Base error class for the ZK Payroll SDK.
+ * All SDK errors extend this class, allowing consumers to catch
+ * any SDK error with a single `instanceof ZkPayrollError` check.
+ */
+export class ZkPayrollError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly context: ErrorContext = {}
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+// ── Network Errors ──────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a network request fails (RPC calls, artifact downloads, etc.).
+ */
+export class NetworkError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: string = "NETWORK_ERROR",
+    context: ErrorContext = {},
+    public readonly statusCode?: number
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Proof Generation Errors ─────────────────────────────────────────────────
+
+/**
+ * Thrown when ZK proof generation fails (circuit errors, artifact issues, etc.).
+ */
+export class ProofGenerationError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: string = "PROOF_GENERATION_FAILED",
+    context: ErrorContext = {}
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Contract Execution Errors ───────────────────────────────────────────────
+
+/** Error codes for Soroban RPC / contract failures */
+export const ContractErrorCode = {
+  SIMULATION_FAILED: "SIMULATION_FAILED",
+  TRANSACTION_SUBMISSION_FAILED: "TRANSACTION_SUBMISSION_FAILED",
+  TRANSACTION_TIMEOUT: "TRANSACTION_TIMEOUT",
+  INSUFFICIENT_FEE: "INSUFFICIENT_FEE",
+  CONTRACT_REVERT: "CONTRACT_REVERT",
+  UNKNOWN_RPC_ERROR: "UNKNOWN_RPC_ERROR",
+} as const;
+
+export type ContractErrorCodeType =
+  (typeof ContractErrorCode)[keyof typeof ContractErrorCode];
+
+/**
+ * Thrown when a Soroban contract call fails (simulation, submission,
+ * timeout, or on-chain revert).
+ */
+export class ContractExecutionError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: ContractErrorCodeType = ContractErrorCode.UNKNOWN_RPC_ERROR,
+    context: ErrorContext = {}
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Validation Errors ───────────────────────────────────────────────────────
+
+/**
+ * Thrown when input validation fails (invalid addresses, amounts, etc.).
+ */
+export class ValidationError extends ZkPayrollError {
+  constructor(
+    message: string,
+    public readonly field: string,
+    code: string = "VALIDATION_ERROR",
+    context: ErrorContext = {}
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Error Mapping Utility ───────────────────────────────────────────────────
+
+/**
+ * Map a raw Soroban RPC error to a typed ContractExecutionError.
+ */
+export function mapRpcError(
+  error: unknown,
+  context: ErrorContext = {}
+): ContractExecutionError {
+  if (error instanceof ContractExecutionError) return error;
+
+  const msg = error instanceof Error ? error.message : String(error);
+
+  if (/simulate/i.test(msg)) {
+    return new ContractExecutionError(
+      `Simulation failed: ${msg}`,
+      ContractErrorCode.SIMULATION_FAILED,
+      context
+    );
+  }
+
+  if (/fee|insufficient/i.test(msg)) {
+    return new ContractExecutionError(
+      `Insufficient fee: ${msg}`,
+      ContractErrorCode.INSUFFICIENT_FEE,
+      context
+    );
+  }
+
+  if (/timeout|expired/i.test(msg)) {
+    return new ContractExecutionError(
+      `Transaction timed out: ${msg}`,
+      ContractErrorCode.TRANSACTION_TIMEOUT,
+      context
+    );
+  }
+
+  if (/revert|trap|wasm/i.test(msg)) {
+    return new ContractExecutionError(
+      `Contract reverted: ${msg}`,
+      ContractErrorCode.CONTRACT_REVERT,
+      context
+    );
+  }
+
+  if (/submit|send/i.test(msg)) {
+    return new ContractExecutionError(
+      `Transaction submission failed: ${msg}`,
+      ContractErrorCode.TRANSACTION_SUBMISSION_FAILED,
+      context
+    );
+  }
+
+  return new ContractExecutionError(
+    `Unknown RPC error: ${msg}`,
+    ContractErrorCode.UNKNOWN_RPC_ERROR,
+    context
+  );
+}

--- a/src/errors.ts
+++ b/src/errors.ts
@@ -1,97 +1,35 @@
-export class PayrollError extends Error {
-  constructor(
-    message: string,
-    public code: number
-  ) {
-    super(message);
+/**
+ * Re-exports from core error module.
+ * Import from "./core/errors" for the full error hierarchy.
+ * This file maintains backward compatibility for existing consumers.
+ */
+export {
+  ZkPayrollError,
+  NetworkError,
+  ProofGenerationError,
+  ContractExecutionError,
+  ValidationError,
+  ContractErrorCode,
+  mapRpcError,
+} from "./core/errors";
+export type { ErrorContext, ContractErrorCodeType } from "./core/errors";
+
+// ── Backward-compatible alias ───────────────────────────────────────────────
+import { ZkPayrollError } from "./core/errors";
+
+/**
+ * @deprecated Use `ZkPayrollError` instead. Kept for backward compatibility.
+ */
+export class PayrollError extends ZkPayrollError {
+  constructor(message: string, code: number) {
+    super(message, String(code));
     this.name = "PayrollError";
   }
 }
 
-// Error codes for Soroban RPC failures
-export const ContractErrorCode = {
-  SIMULATION_FAILED: 1001,
-  TRANSACTION_SUBMISSION_FAILED: 1002,
-  TRANSACTION_TIMEOUT: 1003,
-  INSUFFICIENT_FEE: 1004,
-  CONTRACT_REVERT: 1005,
-  UNKNOWN_RPC_ERROR: 1099,
-} as const;
-
-export type ContractErrorCode = (typeof ContractErrorCode)[keyof typeof ContractErrorCode];
-
 /**
- * Wraps Soroban RPC errors with a structured code so callers can
- * branch on error type without string-matching raw RPC messages.
+ * @deprecated Use structured error logging instead.
  */
-export class ContractExecutionError extends PayrollError {
-  constructor(
-    message: string,
-    code: ContractErrorCode,
-    public readonly cause?: unknown
-  ) {
-    super(message, code);
-    this.name = "ContractExecutionError";
-  }
-}
-
-/**
- * Map a raw Soroban RPC error to a typed ContractExecutionError.
- * Inspect the error message/shape coming back from the RPC layer and
- * assign the closest ContractErrorCode.
- */
-export function mapRpcError(error: unknown): ContractExecutionError {
-  if (error instanceof ContractExecutionError) return error;
-
-  const msg = error instanceof Error ? error.message : String(error);
-
-  if (/simulate/i.test(msg)) {
-    return new ContractExecutionError(
-      `Simulation failed: ${msg}`,
-      ContractErrorCode.SIMULATION_FAILED,
-      error
-    );
-  }
-
-  if (/fee|insufficient/i.test(msg)) {
-    return new ContractExecutionError(
-      `Insufficient fee: ${msg}`,
-      ContractErrorCode.INSUFFICIENT_FEE,
-      error
-    );
-  }
-
-  if (/timeout|expired/i.test(msg)) {
-    return new ContractExecutionError(
-      `Transaction timed out: ${msg}`,
-      ContractErrorCode.TRANSACTION_TIMEOUT,
-      error
-    );
-  }
-
-  if (/revert|trap|wasm/i.test(msg)) {
-    return new ContractExecutionError(
-      `Contract reverted: ${msg}`,
-      ContractErrorCode.CONTRACT_REVERT,
-      error
-    );
-  }
-
-  if (/submit|send/i.test(msg)) {
-    return new ContractExecutionError(
-      `Transaction submission failed: ${msg}`,
-      ContractErrorCode.TRANSACTION_SUBMISSION_FAILED,
-      error
-    );
-  }
-
-  return new ContractExecutionError(
-    `Unknown RPC error: ${msg}`,
-    ContractErrorCode.UNKNOWN_RPC_ERROR,
-    error
-  );
-}
-
 export function handleApiError(error: unknown): void {
   // eslint-disable-next-line no-console
   console.error("API Error:", error);

--- a/src/index.ts
+++ b/src/index.ts
@@ -2,7 +2,17 @@ export { PayrollService } from "./payroll";
 export { PayrollContract } from "./contract";
 export { ZKProofGenerator } from "./crypto/proofs";
 export { SnarkjsProofGenerator } from "./crypto/SnarkjsProofGenerator";
-export { PayrollError } from "./errors";
+export {
+  ZkPayrollError,
+  NetworkError,
+  ProofGenerationError,
+  ContractExecutionError,
+  ValidationError,
+  ContractErrorCode,
+  mapRpcError,
+  PayrollError,
+} from "./errors";
+export type { ErrorContext, ContractErrorCodeType } from "./errors";
 export { DEFAULT_CONFIG } from "./config";
 export * from "./cache";
 export * from "./types";

--- a/tests/core-errors.test.ts
+++ b/tests/core-errors.test.ts
@@ -1,0 +1,178 @@
+import {
+  ZkPayrollError,
+  NetworkError,
+  ProofGenerationError,
+  ContractExecutionError,
+  ValidationError,
+  ContractErrorCode,
+  mapRpcError,
+} from "../src/core/errors";
+import { PayrollError } from "../src/errors";
+
+describe("Core Error Classes", () => {
+  describe("ZkPayrollError", () => {
+    it("sets name to constructor name", () => {
+      const error = new ZkPayrollError("test", "TEST_CODE");
+      expect(error.name).toBe("ZkPayrollError");
+    });
+
+    it("stores code and context", () => {
+      const error = new ZkPayrollError("msg", "CODE_1", {
+        transactionId: "tx_123",
+      });
+      expect(error.code).toBe("CODE_1");
+      expect(error.context.transactionId).toBe("tx_123");
+      expect(error.message).toBe("msg");
+    });
+
+    it("defaults context to empty object", () => {
+      const error = new ZkPayrollError("msg", "CODE");
+      expect(error.context).toEqual({});
+    });
+
+    it("is instanceof Error", () => {
+      const error = new ZkPayrollError("msg", "CODE");
+      expect(error).toBeInstanceOf(Error);
+    });
+  });
+
+  describe("NetworkError", () => {
+    it("extends ZkPayrollError", () => {
+      const error = new NetworkError("timeout");
+      expect(error).toBeInstanceOf(ZkPayrollError);
+      expect(error.name).toBe("NetworkError");
+    });
+
+    it("stores statusCode", () => {
+      const error = new NetworkError("not found", "HTTP_404", {}, 404);
+      expect(error.statusCode).toBe(404);
+    });
+
+    it("defaults code to NETWORK_ERROR", () => {
+      const error = new NetworkError("fail");
+      expect(error.code).toBe("NETWORK_ERROR");
+    });
+  });
+
+  describe("ProofGenerationError", () => {
+    it("extends ZkPayrollError", () => {
+      const error = new ProofGenerationError("circuit failed");
+      expect(error).toBeInstanceOf(ZkPayrollError);
+      expect(error.name).toBe("ProofGenerationError");
+    });
+
+    it("defaults code to PROOF_GENERATION_FAILED", () => {
+      const error = new ProofGenerationError("bad witness");
+      expect(error.code).toBe("PROOF_GENERATION_FAILED");
+    });
+
+    it("accepts context metadata", () => {
+      const error = new ProofGenerationError("fail", "PROOF_GENERATION_FAILED", {
+        contractId: "C_ABC",
+      });
+      expect(error.context.contractId).toBe("C_ABC");
+    });
+  });
+
+  describe("ContractExecutionError", () => {
+    it("extends ZkPayrollError", () => {
+      const error = new ContractExecutionError("revert");
+      expect(error).toBeInstanceOf(ZkPayrollError);
+      expect(error.name).toBe("ContractExecutionError");
+    });
+
+    it("accepts ContractErrorCode values", () => {
+      const error = new ContractExecutionError(
+        "sim failed",
+        ContractErrorCode.SIMULATION_FAILED,
+        { transactionId: "tx_456" }
+      );
+      expect(error.code).toBe("SIMULATION_FAILED");
+      expect(error.context.transactionId).toBe("tx_456");
+    });
+
+    it("defaults to UNKNOWN_RPC_ERROR", () => {
+      const error = new ContractExecutionError("unknown");
+      expect(error.code).toBe("UNKNOWN_RPC_ERROR");
+    });
+  });
+
+  describe("ValidationError", () => {
+    it("extends ZkPayrollError", () => {
+      const error = new ValidationError("invalid", "recipient");
+      expect(error).toBeInstanceOf(ZkPayrollError);
+      expect(error.name).toBe("ValidationError");
+    });
+
+    it("stores the field name", () => {
+      const error = new ValidationError("too small", "amount");
+      expect(error.field).toBe("amount");
+    });
+
+    it("defaults code to VALIDATION_ERROR", () => {
+      const error = new ValidationError("bad", "asset");
+      expect(error.code).toBe("VALIDATION_ERROR");
+    });
+  });
+
+  describe("mapRpcError", () => {
+    it("returns existing ContractExecutionError unchanged", () => {
+      const original = new ContractExecutionError("existing");
+      expect(mapRpcError(original)).toBe(original);
+    });
+
+    it("maps simulation errors", () => {
+      const result = mapRpcError(new Error("simulate transaction failed"));
+      expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+    });
+
+    it("maps fee errors", () => {
+      const result = mapRpcError(new Error("insufficient fee"));
+      expect(result.code).toBe(ContractErrorCode.INSUFFICIENT_FEE);
+    });
+
+    it("maps timeout errors", () => {
+      const result = mapRpcError(new Error("transaction timeout"));
+      expect(result.code).toBe(ContractErrorCode.TRANSACTION_TIMEOUT);
+    });
+
+    it("maps revert errors", () => {
+      const result = mapRpcError(new Error("contract revert"));
+      expect(result.code).toBe(ContractErrorCode.CONTRACT_REVERT);
+    });
+
+    it("maps submission errors", () => {
+      const result = mapRpcError(new Error("failed to submit"));
+      expect(result.code).toBe(ContractErrorCode.TRANSACTION_SUBMISSION_FAILED);
+    });
+
+    it("maps unknown errors", () => {
+      const result = mapRpcError(new Error("something else"));
+      expect(result.code).toBe(ContractErrorCode.UNKNOWN_RPC_ERROR);
+    });
+
+    it("passes context through", () => {
+      const result = mapRpcError(new Error("fail"), {
+        transactionId: "tx_789",
+      });
+      expect(result.context.transactionId).toBe("tx_789");
+    });
+  });
+
+  describe("PayrollError (backward compat)", () => {
+    it("extends ZkPayrollError", () => {
+      const error = new PayrollError("test", 500);
+      expect(error).toBeInstanceOf(ZkPayrollError);
+    });
+
+    it("converts numeric code to string", () => {
+      const error = new PayrollError("test", 1001);
+      expect(error.code).toBe("1001");
+    });
+
+    it("keeps name as PayrollError", () => {
+      const error = new PayrollError("test", 500);
+      expect(error.name).toBe("PayrollError");
+    });
+  });
+});


### PR DESCRIPTION
Closes #19 

## Summary
  - Created `src/core/errors.ts` with `ZkPayrollError` base class extending `Error`
  - Added subclasses: `NetworkError` (with statusCode), `ProofGenerationError`, `ContractExecutionError` (with string-based `ContractErrorCode`), `ValidationError` (with
   field name)
  - All errors carry `ErrorContext` metadata (`transactionId`, `contractId`, `network`, etc.)
  - Updated `BaseContractWrapper` to use string-based `ContractErrorCode` constants
  - `src/errors.ts` re-exports everything + keeps `PayrollError` alias for backward compat
  - 27 new tests, 80 total passing

  ## Test plan
  - [x] Unit tests for all error classes, inheritance, defaults, and context
  - [x] Unit tests for `mapRpcError` utility with context passthrough
  - [x] Backward compatibility test for `PayrollError`
  - [x] All existing tests still passing