### PR TITLE
feat: add config presets for local, testnet, and production environments

### DIFF
--- a/packages/core/src/config-presets.ts
+++ b/packages/core/src/config-presets.ts
@@ -1,0 +1,88 @@
+import { ValidationError } from "./errors";
+import { ClientConfig } from "./config";
+
+/**
+ * Full SDK configuration including proof artifact locations.
+ */
+export interface SdkConfig extends ClientConfig {
+  /** URL or path to the circuit .wasm file */
+  wasmUrl: string;
+  /** URL or path to the proving key .zkey file */
+  zkeyUrl: string;
+}
+
+// ── Preset factories ─────────────────────────────────────────────────────────
+
+/**
+ * Local development preset.
+ * Assumes a local Soroban network (e.g. `stellar-quickstart`) on port 8000
+ * and circuit artifacts served from localhost.
+ */
+export function localPreset(overrides: Partial<SdkConfig> = {}): SdkConfig {
+  return {
+    networkUrl: "http://localhost:8000/soroban/rpc",
+    contractId: "",
+    wasmUrl: "http://localhost:3000/payroll_circuit.wasm",
+    zkeyUrl: "http://localhost:3000/payroll_circuit.zkey",
+    ...overrides,
+  };
+}
+
+/**
+ * Stellar Testnet preset.
+ * Uses the public Soroban testnet RPC and a CDN for circuit artifacts.
+ */
+export function testnetPreset(overrides: Partial<SdkConfig> = {}): SdkConfig {
+  return {
+    networkUrl: "https://soroban-testnet.stellar.org",
+    contractId: "",
+    wasmUrl: "https://cdn.zkpayroll.dev/testnet/payroll_circuit.wasm",
+    zkeyUrl: "https://cdn.zkpayroll.dev/testnet/payroll_circuit.zkey",
+    ...overrides,
+  };
+}
+
+/**
+ * Production (Mainnet) preset.
+ * Uses the public Soroban mainnet RPC and production CDN artifacts.
+ * A `contractId` MUST be supplied via `overrides`.
+ */
+export function productionPreset(
+  overrides: Partial<SdkConfig> = {}
+): SdkConfig {
+  return {
+    networkUrl: "https://soroban.stellar.org",
+    contractId: "",
+    wasmUrl: "https://cdn.zkpayroll.dev/mainnet/payroll_circuit.wasm",
+    zkeyUrl: "https://cdn.zkpayroll.dev/mainnet/payroll_circuit.zkey",
+    ...overrides,
+  };
+}
+
+// ── Validation ───────────────────────────────────────────────────────────────
+
+const REQUIRED_FIELDS: (keyof SdkConfig)[] = [
+  "networkUrl",
+  "contractId",
+  "wasmUrl",
+  "zkeyUrl",
+];
+
+/**
+ * Validate an SdkConfig, throwing a `ValidationError` for the first missing
+ * or blank required field.
+ *
+ * @throws {ValidationError} if any required field is absent or empty.
+ */
+export function validateConfig(config: SdkConfig): void {
+  for (const field of REQUIRED_FIELDS) {
+    const value = config[field];
+    if (!value || (typeof value === "string" && value.trim() === "")) {
+      throw new ValidationError(
+        `Config field "${field}" is required and must not be empty`,
+        field,
+        "INVALID_CONFIG"
+      );
+    }
+  }
+}

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -1,0 +1,167 @@
+/**
+ * Context metadata attached to SDK errors for debugging.
+ */
+export interface ErrorContext {
+  /** Transaction hash related to the error */
+  transactionId?: string;
+  /** Contract ID involved */
+  contractId?: string;
+  /** Network (testnet/mainnet) */
+  network?: string;
+  /** Arbitrary additional context */
+  [key: string]: unknown;
+}
+
+// ── Base Error ──────────────────────────────────────────────────────────────
+
+/**
+ * Base error class for the ZK Payroll SDK.
+ * All SDK errors extend this class, allowing consumers to catch
+ * any SDK error with a single `instanceof ZkPayrollError` check.
+ */
+export class ZkPayrollError extends Error {
+  constructor(
+    message: string,
+    public readonly code: string,
+    public readonly context: ErrorContext = {}
+  ) {
+    super(message);
+    this.name = this.constructor.name;
+  }
+}
+
+// ── Network Errors ──────────────────────────────────────────────────────────
+
+/**
+ * Thrown when a network request fails (RPC calls, artifact downloads, etc.).
+ */
+export class NetworkError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: string = "NETWORK_ERROR",
+    context: ErrorContext = {},
+    public readonly statusCode?: number
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Proof Generation Errors ─────────────────────────────────────────────────
+
+/**
+ * Thrown when ZK proof generation fails (circuit errors, artifact issues, etc.).
+ */
+export class ProofGenerationError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: string = "PROOF_GENERATION_FAILED",
+    context: ErrorContext = {}
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Contract Execution Errors ───────────────────────────────────────────────
+
+/** Error codes for Soroban RPC / contract failures */
+export const ContractErrorCode = {
+  SIMULATION_FAILED: "SIMULATION_FAILED",
+  TRANSACTION_SUBMISSION_FAILED: "TRANSACTION_SUBMISSION_FAILED",
+  TRANSACTION_TIMEOUT: "TRANSACTION_TIMEOUT",
+  INSUFFICIENT_FEE: "INSUFFICIENT_FEE",
+  CONTRACT_REVERT: "CONTRACT_REVERT",
+  UNKNOWN_RPC_ERROR: "UNKNOWN_RPC_ERROR",
+} as const;
+
+export type ContractErrorCodeType =
+  (typeof ContractErrorCode)[keyof typeof ContractErrorCode];
+
+/**
+ * Thrown when a Soroban contract call fails (simulation, submission,
+ * timeout, or on-chain revert).
+ */
+export class ContractExecutionError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: ContractErrorCodeType = ContractErrorCode.UNKNOWN_RPC_ERROR,
+    context: ErrorContext = {}
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Validation Errors ───────────────────────────────────────────────────────
+
+/**
+ * Thrown when input validation fails (invalid addresses, amounts, etc.).
+ */
+export class ValidationError extends ZkPayrollError {
+  constructor(
+    message: string,
+    public readonly field: string,
+    code: string = "VALIDATION_ERROR",
+    context: ErrorContext = {}
+  ) {
+    super(message, code, context);
+  }
+}
+
+// ── Error Mapping Utility ───────────────────────────────────────────────────
+
+/**
+ * Map a raw Soroban RPC error to a typed ContractExecutionError.
+ */
+export function mapRpcError(
+  error: unknown,
+  context: ErrorContext = {}
+): ContractExecutionError {
+  if (error instanceof ContractExecutionError) return error;
+
+  const msg = error instanceof Error ? error.message : String(error);
+
+  if (/simulate/i.test(msg)) {
+    return new ContractExecutionError(
+      `Simulation failed: ${msg}`,
+      ContractErrorCode.SIMULATION_FAILED,
+      context
+    );
+  }
+
+  if (/fee|insufficient/i.test(msg)) {
+    return new ContractExecutionError(
+      `Insufficient fee: ${msg}`,
+      ContractErrorCode.INSUFFICIENT_FEE,
+      context
+    );
+  }
+
+  if (/timeout|expired/i.test(msg)) {
+    return new ContractExecutionError(
+      `Transaction timed out: ${msg}`,
+      ContractErrorCode.TRANSACTION_TIMEOUT,
+      context
+    );
+  }
+
+  if (/revert|trap|wasm/i.test(msg)) {
+    return new ContractExecutionError(
+      `Contract reverted: ${msg}`,
+      ContractErrorCode.CONTRACT_REVERT,
+      context
+    );
+  }
+
+  if (/submit|send/i.test(msg)) {
+    return new ContractExecutionError(
+      `Transaction submission failed: ${msg}`,
+      ContractErrorCode.TRANSACTION_SUBMISSION_FAILED,
+      context
+    );
+  }
+
+  return new ContractExecutionError(
+    `Unknown RPC error: ${msg}`,
+    ContractErrorCode.UNKNOWN_RPC_ERROR,
+    context
+  );
+}

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -1,25 +1,3 @@
-export class PayrollError extends Error {
-  constructor(
-    message: string,
-    public code: number
-  ) {
-    super(message);
-    this.name = "PayrollError";
-  }
-}
-
-// Error codes for Soroban RPC failures
-export const ContractErrorCode = {
-  SIMULATION_FAILED: 1001,
-  TRANSACTION_SUBMISSION_FAILED: 1002,
-  TRANSACTION_TIMEOUT: 1003,
-  INSUFFICIENT_FEE: 1004,
-  CONTRACT_REVERT: 1005,
-  UNKNOWN_RPC_ERROR: 1099,
-} as const;
-
-export type ContractErrorCode = (typeof ContractErrorCode)[keyof typeof ContractErrorCode];
-
 // Error codes for PayrollService validation/orchestration failures
 export const PayrollServiceErrorCode = {
   PROOF_GENERATION_FAILED: 2001,
@@ -33,8 +11,6 @@ export type PayrollServiceErrorCode =
 
 /**
  * Re-exports from core error module.
- * Import from "./core/errors" for the full error hierarchy.
- * This file maintains backward compatibility for existing consumers.
  */
 export {
   ZkPayrollError,
@@ -47,15 +23,16 @@ export {
 } from "./core/errors";
 export type { ErrorContext, ContractErrorCodeType } from "./core/errors";
 
-// ── Backward-compatible alias ───────────────────────────────────────────────
 import { ZkPayrollError } from "./core/errors";
 
 /**
- * @deprecated Use `ZkPayrollError` instead. Kept for backward compatibility.
+ * Legacy-compatible error for PayrollService orchestration failures.
+ * Extends ZkPayrollError so `instanceof ZkPayrollError` checks pass.
+ * The numeric constructor argument is stored as a string code.
  */
 export class PayrollError extends ZkPayrollError {
-  constructor(message: string, code: number) {
-    super(message, String(code));
+  constructor(message: string, numericCode: number) {
+    super(message, String(numericCode));
     this.name = "PayrollError";
   }
 }

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -30,6 +30,13 @@ export {
 } from "./errors";
 export type { ErrorContext, ContractErrorCodeType } from "./errors";
 export { DEFAULT_CONFIG } from "./config";
+export {
+  localPreset,
+  testnetPreset,
+  productionPreset,
+  validateConfig,
+} from "./config-presets";
+export type { SdkConfig } from "./config-presets";
 export * from "./cache";
 export * from "./types";
 export * from "./crypto/IProofGenerator";

--- a/packages/core/tests/config-presets.test.ts
+++ b/packages/core/tests/config-presets.test.ts
@@ -1,0 +1,132 @@
+import {
+  localPreset,
+  testnetPreset,
+  productionPreset,
+  validateConfig,
+  SdkConfig,
+} from "../src/config-presets";
+import { ValidationError } from "../src/errors";
+
+const VALID_CONFIG: SdkConfig = {
+  networkUrl: "https://soroban-testnet.stellar.org",
+  contractId: "CABC123",
+  wasmUrl: "https://cdn.example.com/payroll_circuit.wasm",
+  zkeyUrl: "https://cdn.example.com/payroll_circuit.zkey",
+};
+
+describe("localPreset", () => {
+  it("returns a config with localhost networkUrl", () => {
+    expect(localPreset().networkUrl).toMatch(/^http:\/\/localhost/);
+  });
+
+  it("returns localhost wasmUrl and zkeyUrl", () => {
+    const cfg = localPreset();
+    expect(cfg.wasmUrl).toMatch(/^http:\/\/localhost/);
+    expect(cfg.zkeyUrl).toMatch(/^http:\/\/localhost/);
+  });
+
+  it("applies overrides", () => {
+    const cfg = localPreset({ contractId: "CLOCAL123" });
+    expect(cfg.contractId).toBe("CLOCAL123");
+  });
+
+  it("override does not mutate other fields", () => {
+    const cfg = localPreset({ contractId: "CLOCAL123" });
+    expect(cfg.networkUrl).toMatch(/^http:\/\/localhost/);
+  });
+});
+
+describe("testnetPreset", () => {
+  it("returns the public testnet RPC URL", () => {
+    expect(testnetPreset().networkUrl).toBe(
+      "https://soroban-testnet.stellar.org"
+    );
+  });
+
+  it("returns testnet CDN URLs for artifacts", () => {
+    const cfg = testnetPreset();
+    expect(cfg.wasmUrl).toContain("testnet");
+    expect(cfg.zkeyUrl).toContain("testnet");
+  });
+
+  it("applies overrides", () => {
+    const cfg = testnetPreset({ contractId: "CTESTNET456" });
+    expect(cfg.contractId).toBe("CTESTNET456");
+    expect(cfg.networkUrl).toBe("https://soroban-testnet.stellar.org");
+  });
+});
+
+describe("productionPreset", () => {
+  it("returns the public mainnet RPC URL", () => {
+    expect(productionPreset().networkUrl).toBe("https://soroban.stellar.org");
+  });
+
+  it("returns mainnet CDN URLs for artifacts", () => {
+    const cfg = productionPreset();
+    expect(cfg.wasmUrl).toContain("mainnet");
+    expect(cfg.zkeyUrl).toContain("mainnet");
+  });
+
+  it("applies overrides including contractId", () => {
+    const cfg = productionPreset({ contractId: "CPROD789" });
+    expect(cfg.contractId).toBe("CPROD789");
+    expect(cfg.networkUrl).toBe("https://soroban.stellar.org");
+  });
+});
+
+describe("validateConfig", () => {
+  it("passes a fully populated config without throwing", () => {
+    expect(() => validateConfig(VALID_CONFIG)).not.toThrow();
+  });
+
+  it.each(["networkUrl", "contractId", "wasmUrl", "zkeyUrl"] as const)(
+    'throws ValidationError when "%s" is empty string',
+    (field) => {
+      const cfg = { ...VALID_CONFIG, [field]: "" };
+      expect(() => validateConfig(cfg)).toThrow(ValidationError);
+    }
+  );
+
+  it.each(["networkUrl", "contractId", "wasmUrl", "zkeyUrl"] as const)(
+    'throws ValidationError when "%s" is whitespace',
+    (field) => {
+      const cfg = { ...VALID_CONFIG, [field]: "   " };
+      expect(() => validateConfig(cfg)).toThrow(ValidationError);
+    }
+  );
+
+  it("error message identifies the missing field", () => {
+    const cfg = { ...VALID_CONFIG, contractId: "" };
+    expect(() => validateConfig(cfg)).toThrow(/contractId/);
+  });
+
+  it("error has code INVALID_CONFIG", () => {
+    const cfg = { ...VALID_CONFIG, wasmUrl: "" };
+    try {
+      validateConfig(cfg);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      expect((e as ValidationError).code).toBe("INVALID_CONFIG");
+    }
+  });
+
+  it("error exposes the field name", () => {
+    const cfg = { ...VALID_CONFIG, zkeyUrl: "" };
+    try {
+      validateConfig(cfg);
+    } catch (e) {
+      expect(e).toBeInstanceOf(ValidationError);
+      expect((e as ValidationError).field).toBe("zkeyUrl");
+    }
+  });
+
+  it("is compatible with preset output after adding required fields", () => {
+    const cfg = testnetPreset({ contractId: "CABC123" });
+    expect(() => validateConfig(cfg)).not.toThrow();
+  });
+
+  it("preset without contractId fails validation", () => {
+    const cfg = productionPreset(); // contractId is ""
+    expect(() => validateConfig(cfg)).toThrow(ValidationError);
+  });
+});

--- a/packages/core/tests/payroll-service.test.ts
+++ b/packages/core/tests/payroll-service.test.ts
@@ -122,7 +122,7 @@ describe("PayrollService", () => {
       await expect(
         service.processPayment({ recipient: "", amount: 100n, asset: "native" })
       ).rejects.toMatchObject({
-        code: PayrollServiceErrorCode.INVALID_RECIPIENT,
+        code: String(PayrollServiceErrorCode.INVALID_RECIPIENT),
       });
     });
 
@@ -137,7 +137,7 @@ describe("PayrollService", () => {
           asset: "native",
         })
       ).rejects.toMatchObject({
-        code: PayrollServiceErrorCode.INVALID_AMOUNT,
+        code: String(PayrollServiceErrorCode.INVALID_AMOUNT),
       });
     });
 
@@ -152,7 +152,7 @@ describe("PayrollService", () => {
           asset: "native",
         })
       ).rejects.toMatchObject({
-        code: PayrollServiceErrorCode.INVALID_AMOUNT,
+        code: String(PayrollServiceErrorCode.INVALID_AMOUNT),
       });
     });
 
@@ -167,7 +167,7 @@ describe("PayrollService", () => {
           asset: "",
         })
       ).rejects.toMatchObject({
-        code: PayrollServiceErrorCode.INVALID_ASSET,
+        code: String(PayrollServiceErrorCode.INVALID_ASSET),
       });
     });
 
@@ -191,7 +191,7 @@ describe("PayrollService", () => {
           asset: "native",
         })
       ).rejects.toMatchObject({
-        code: PayrollServiceErrorCode.PROOF_GENERATION_FAILED,
+        code: String(PayrollServiceErrorCode.PROOF_GENERATION_FAILED),
         message: expect.stringContaining("circuit mismatch"),
       });
     });


### PR DESCRIPTION
Closes #41 
- Add SdkConfig interface extending ClientConfig with wasmUrl/zkeyUrl
- Add localPreset, testnetPreset, productionPreset factory functions
- Add validateConfig with fast-fail ValidationError on missing fields
- Export new symbols from package index
- Fix pre-existing broken errors.ts (missing core/errors module, duplicate identifiers)
- Add 17 tests covering presets, validation, and error shape

Closes #41