### PR TITLE
Add typed SDK clients for payroll contract modules

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ await service.processPayment(
 
 ## Features
 
-- **Contract Wrappers**: Typed interfaces for Soroban contracts.
+- **Typed Contract Clients**: Fully typed client wrappers for PayrollRegistry, SalaryCommitment, ProofVerifier, and PaymentExecutor contracts.
 - **ZK Proof Generation**: Client-side proof generation using snarkjs for privacy.
 - **Caching**: Built-in caching for proofs and circuit artifacts.
 - **Error Handling**: Robust error typing and management.
@@ -77,6 +77,117 @@ const txHash = await mockContract.deposit(1000n);
 ```
 
 See the [Testing Guide](docs/TESTING.md) for complete documentation.
+
+## Typed Contract Clients
+
+The SDK provides typed client wrappers for the core ZK Payroll contracts. Each client exposes typed methods that encode arguments and decode responses automatically.
+
+### PayrollRegistryClient
+
+```typescript
+import { PayrollRegistryClient, rpc } from "@zk-payroll/sdk";
+
+const server = new rpc.Server("https://soroban-testnet.stellar.org");
+const client = new PayrollRegistryClient(server, "CCONTRACT_ID...");
+
+// Register a payroll relationship
+await client.register(
+  { employer: "G...", employee: "G...", salary: 1000n, token: "C...", metadata: "engineering" },
+  signer
+);
+
+// Query a registry entry
+const entry = await client.getRegistry("G...", "G...", signer);
+console.log(entry.salary, entry.active);
+
+// List employees
+const employees = await client.getEmployees("G...", 0, 10, signer);
+
+// Check if a registry exists
+const exists = await client.registryExists("G...", "G...", signer);
+```
+
+### SalaryCommitmentClient
+
+```typescript
+import { SalaryCommitmentClient } from "@zk-payroll/sdk";
+
+const client = new SalaryCommitmentClient(server, "CCONTRACT_ID...");
+
+// Commit to a salary amount (hidden via hash)
+await client.commit(
+  { employer: "G...", employee: "G...", commitmentHash: "abcd...", cycleId: 1n },
+  signer
+);
+
+// Retrieve a commitment
+const commitment = await client.getCommitment("G...", "G...", 1n, signer);
+
+// Batch commit multiple salaries
+await client.batchCommit("G...", [
+  { employee: "G...1", commitmentHash: "abcd", cycleId: 1n },
+  { employee: "G...2", commitmentHash: "ef01", cycleId: 1n },
+], signer);
+
+// Verify a commitment against a ZK proof
+const isValid = await client.verifyCommitment("G...", "G...", 1n, proof, signer);
+
+// Reveal the actual salary
+await client.revealSalary("G...", "G...", 1n, 1000n, signer);
+```
+
+### ProofVerifierClient
+
+```typescript
+import { ProofVerifierClient } from "@zk-payroll/sdk";
+
+const client = new ProofVerifierClient(server, "CCONTRACT_ID...");
+
+// Verify a ZK proof on-chain
+const valid = await client.verify(
+  { pi_a: ["1","2"], pi_b: [["3","4"],["5","6"]], pi_c: ["7","8"], publicSignals: ["sig1"] },
+  ["input1"],
+  1, // verification key ID
+  signer
+);
+
+// Add a new verification key
+const vkId = await client.addVerificationKey("aabbcc...", "groth16 key", signer);
+
+// Get active verification key
+const activeId = await client.getActiveVerificationKeyId(signer);
+
+// Get verification key info
+const info = await client.getVerificationKeyInfo(1, signer);
+```
+
+### PaymentExecutorClient
+
+```typescript
+import { PaymentExecutorClient } from "@zk-payroll/sdk";
+
+const client = new PaymentExecutorClient(server, "CCONTRACT_ID...");
+
+// Execute an immediate payment
+const result = await client.execute(
+  { recipient: "G...", amount: 1000n, asset: "C...", memo: "salary" },
+  signer
+);
+console.log("Transaction:", result.txHash);
+
+// Schedule a future payment
+const scheduled = await client.schedule(
+  { recipient: "G...", amount: 500n, asset: "C...", executeAt: 1700000000, memo: "bonus" },
+  signer
+);
+console.log("Payment ID:", scheduled.paymentId);
+
+// Cancel a scheduled payment
+await client.cancel(scheduled.paymentId, signer);
+
+// Get pending payments
+const payments = await client.getPendingPayments("G...", 0n, 20, signer);
+```
 
 ## Documentation
 

--- a/docs/API.md
+++ b/docs/API.md
@@ -2,6 +2,277 @@
 
 ## Classes
 
+### Typed Contract Clients
+
+The SDK provides fully typed client wrappers for the core ZK Payroll Soroban contracts. Each client extends `BaseContractWrapper` and handles XDR encoding/decoding automatically.
+
+### `PayrollRegistryClient`
+
+Typed client for the `payroll_registry` contract. Manages employer-employee payroll relationships.
+
+#### `constructor(server: rpc.Server, contractId: string, options?: ClientOptions)`
+
+| Param | Type | Description |
+|---|---|---|
+| `server` | `rpc.Server` | Soroban RPC server instance |
+| `contractId` | `string` | Deployed contract address |
+| `options.networkPassphrase` | `string` | Network passphrase (default: `Networks.TESTNET`) |
+
+#### `register(request: RegisterRequest, signer: Keypair, network?: string): Promise<void>`
+
+Registers a new payroll relationship.
+
+```typescript
+interface RegisterRequest {
+  employer: string;   // Stellar address
+  employee: string;   // Stellar address
+  salary: bigint;     // Amount in stroops
+  token: string;      // Token contract address
+  metadata?: string;  // Optional description
+}
+```
+
+#### `getRegistry(employer: string, employee: string, signer: Keypair, network?: string): Promise<RegistryEntry>`
+
+Returns the payroll registry entry for an employer-employee pair.
+
+```typescript
+interface RegistryEntry {
+  employer: string;
+  employee: string;
+  salary: bigint;
+  token: string;
+  metadata: string;
+  active: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+```
+
+#### `updateRegistry(request: UpdateRegistryRequest, signer: Keypair, network?: string): Promise<void>`
+
+Updates the salary for an existing registry entry.
+
+```typescript
+interface UpdateRegistryRequest {
+  employer: string;
+  employee: string;
+  salary: bigint;
+}
+```
+
+#### `deactivateRegistry(employer: string, employee: string, signer: Keypair, network?: string): Promise<void>`
+
+Deactivates a payroll registry entry.
+
+#### `getEmployeeCount(employer: string, signer: Keypair, network?: string): Promise<number>`
+
+Returns the number of employees registered under an employer.
+
+#### `getEmployees(employer: string, start: number, limit: number, signer: Keypair, network?: string): Promise<string[]>`
+
+Returns a paginated list of employee addresses for an employer.
+
+#### `registryExists(employer: string, employee: string, signer: Keypair, network?: string): Promise<boolean>`
+
+Checks if a registry entry exists for the given employer-employee pair.
+
+---
+
+### `SalaryCommitmentClient`
+
+Typed client for the `salary_commitment` contract. Handles salary commitments with ZK proof verification.
+
+#### `constructor(server: rpc.Server, contractId: string, options?: ClientOptions)`
+
+Same constructor pattern as `PayrollRegistryClient`.
+
+#### `commit(request: CommitRequest, signer: Keypair, network?: string): Promise<void>`
+
+Commits to a salary amount for a specific pay cycle using a hash.
+
+```typescript
+interface CommitRequest {
+  employer: string;
+  employee: string;
+  commitmentHash: string;  // Hex-encoded hash
+  cycleId: bigint;
+}
+```
+
+#### `getCommitment(employer: string, employee: string, cycleId: bigint, signer: Keypair, network?: string): Promise<CommitmentEntry>`
+
+Returns the salary commitment for a specific cycle.
+
+```typescript
+interface CommitmentEntry {
+  employer: string;
+  employee: string;
+  commitmentHash: string;
+  cycleId: bigint;
+  createdAt: number;
+  revealed: boolean;
+  actualAmount: bigint;
+}
+```
+
+#### `batchCommit(employer: string, commitments: BatchCommitItem[], signer: Keypair, network?: string): Promise<void>`
+
+Commits multiple salaries in a single transaction.
+
+```typescript
+interface BatchCommitItem {
+  employee: string;
+  commitmentHash: string;
+  cycleId: bigint;
+}
+```
+
+#### `verifyCommitment(employer: string, employee: string, cycleId: bigint, proof: ProofStruct, signer: Keypair, network?: string): Promise<boolean>`
+
+Verifies a salary commitment against a ZK proof.
+
+#### `revealSalary(employer: string, employee: string, cycleId: bigint, actualAmount: bigint, signer: Keypair, network?: string): Promise<void>`
+
+Reveals the actual salary for a previously committed cycle.
+
+#### `getCommitmentCount(employer: string, employee: string, signer: Keypair, network?: string): Promise<number>`
+
+Returns the number of commitment cycles for an employer-employee pair.
+
+---
+
+### `ProofVerifierClient`
+
+Typed client for the `proof_verifier` contract. Manages ZK proof verification and verification keys.
+
+#### `constructor(server: rpc.Server, contractId: string, options?: ClientOptions)`
+
+Same constructor pattern.
+
+#### `verify(proof: ProofStruct, publicInputs: string[], verificationKeyId: number, signer: Keypair, network?: string): Promise<boolean>`
+
+Verifies a ZK proof against a verification key.
+
+```typescript
+interface ProofStruct {
+  pi_a: [string, string];
+  pi_b: [[string, string], [string, string]];
+  pi_c: [string, string];
+  publicSignals: string[];
+}
+```
+
+#### `addVerificationKey(vk: string, description: string, signer: Keypair, network?: string): Promise<number>`
+
+Adds a new verification key and returns its ID.
+
+#### `getVerificationKey(id: number, signer: Keypair, network?: string): Promise<string>`
+
+Returns the raw verification key bytes as hex.
+
+#### `setActiveVerificationKey(id: number, signer: Keypair, network?: string): Promise<void>`
+
+Sets the active verification key by ID.
+
+#### `getActiveVerificationKeyId(signer: Keypair, network?: string): Promise<number>`
+
+Returns the ID of the currently active verification key.
+
+#### `getVerificationKeyCount(signer: Keypair, network?: string): Promise<number>`
+
+Returns the total number of verification keys stored.
+
+#### `getVerificationKeyInfo(id: number, signer: Keypair, network?: string): Promise<VerificationKeyInfo>`
+
+Returns metadata for a verification key.
+
+```typescript
+interface VerificationKeyInfo {
+  id: number;
+  description: string;
+  key: string;  // Hex-encoded
+}
+```
+
+---
+
+### `PaymentExecutorClient`
+
+Typed client for the `payment_executor` contract. Handles executing and scheduling payments.
+
+#### `constructor(server: rpc.Server, contractId: string, options?: ClientOptions)`
+
+Same constructor pattern.
+
+#### `execute(request: ExecutePaymentRequest, signer: Keypair, network?: string): Promise<ExecutePaymentResponse>`
+
+Executes an immediate payment.
+
+```typescript
+interface ExecutePaymentRequest {
+  recipient: string;
+  amount: bigint;
+  asset: string;
+  memo?: string;
+}
+
+interface ExecutePaymentResponse {
+  txHash: string;
+}
+```
+
+#### `schedule(request: SchedulePaymentRequest, signer: Keypair, network?: string): Promise<SchedulePaymentResponse>`
+
+Schedules a future payment.
+
+```typescript
+interface SchedulePaymentRequest {
+  recipient: string;
+  amount: bigint;
+  asset: string;
+  executeAt: number;   // Unix timestamp
+  memo?: string;
+}
+
+interface SchedulePaymentResponse {
+  paymentId: bigint;
+}
+```
+
+#### `cancel(paymentId: bigint, signer: Keypair, network?: string): Promise<void>`
+
+Cancels a scheduled payment.
+
+#### `getScheduledPayment(paymentId: bigint, signer: Keypair, network?: string): Promise<ScheduledPayment>`
+
+Returns details of a scheduled payment.
+
+```typescript
+interface ScheduledPayment {
+  id: bigint;
+  employer: string;
+  recipient: string;
+  amount: bigint;
+  asset: string;
+  executeAt: number;
+  memo: string;
+  executed: boolean;
+  cancelled: boolean;
+  createdAt: number;
+}
+```
+
+#### `getPendingPayments(employer: string, start: bigint, limit: number, signer: Keypair, network?: string): Promise<ScheduledPayment[]>`
+
+Returns a paginated list of pending (non-executed, non-cancelled) payments for an employer.
+
+#### `getPaymentCount(employer: string, signer: Keypair, network?: string): Promise<number>`
+
+Returns the total number of payments scheduled by an employer.
+
+---
+
 ### `PayrollService`
 
 Main entry point for payroll operations.
@@ -105,6 +376,129 @@ Browser localStorage-based cache (persists across sessions).
 Creates a new localStorage cache with optional key prefix.
 
 ## Usage Examples
+
+### Typed Client — PayrollRegistryClient
+
+```typescript
+import { rpc, Keypair } from "@stellar/stellar-sdk";
+import { PayrollRegistryClient } from "@zk-payroll/sdk";
+
+const server = new rpc.Server("https://soroban-testnet.stellar.org");
+const signer = Keypair.fromSecret("S...");
+
+const registry = new PayrollRegistryClient(server, "CCONTRACT_ID...");
+
+// Register a new employee
+await registry.register({
+  employer: "GEMPLOYER...",
+  employee: "GEMPLOYEE...",
+  salary: 1000n,
+  token: "CTOKEN...",
+  metadata: "engineering",
+}, signer);
+
+// Query
+const entry = await registry.getRegistry("GEMPLOYER...", "GEMPLOYEE...", signer);
+console.log(entry.active, entry.salary);
+
+// Update salary
+await registry.updateRegistry({
+  employer: "GEMPLOYER...",
+  employee: "GEMPLOYEE...",
+  salary: 2000n,
+}, signer);
+
+// Paginated employee list
+const employees = await registry.getEmployees("GEMPLOYER...", 0, 10, signer);
+
+// Deactivate
+await registry.deactivateRegistry("GEMPLOYER...", "GEMPLOYEE...", signer);
+```
+
+### Typed Client — SalaryCommitmentClient
+
+```typescript
+import { SalaryCommitmentClient } from "@zk-payroll/sdk";
+
+const client = new SalaryCommitmentClient(server, "CCONTRACT_ID...");
+
+// Commit to a salary
+await client.commit({
+  employer: "GEMPLOYER...",
+  employee: "GEMPLOYEE...",
+  commitmentHash: "deadbeef...",
+  cycleId: 1n,
+}, signer);
+
+// Retrieve commitment
+const commitment = await client.getCommitment("GEMPLOYER...", "GEMPLOYEE...", 1n, signer);
+
+// Batch commit
+await client.batchCommit("GEMPLOYER...", [
+  { employee: "G1...", commitmentHash: "abcd", cycleId: 1n },
+  { employee: "G2...", commitmentHash: "ef01", cycleId: 1n },
+], signer);
+
+// Reveal salary
+await client.revealSalary("GEMPLOYER...", "GEMPLOYEE...", 1n, 1500n, signer);
+```
+
+### Typed Client — ProofVerifierClient
+
+```typescript
+import { ProofVerifierClient } from "@zk-payroll/sdk";
+
+const client = new ProofVerifierClient(server, "CCONTRACT_ID...");
+
+// Verify a proof
+const valid = await client.verify(
+  { pi_a: ["1","2"], pi_b: [["3","4"],["5","6"]], pi_c: ["7","8"], publicSignals: ["sig"] },
+  ["public_input"],
+  1,  // verification key ID
+  signer
+);
+
+// Add verification key
+const vkId = await client.addVerificationKey("aabbccdd...", "groth16 bn128", signer);
+
+// Query key info
+const info = await client.getVerificationKeyInfo(vkId, signer);
+
+// Set as active
+await client.setActiveVerificationKey(vkId, signer);
+```
+
+### Typed Client — PaymentExecutorClient
+
+```typescript
+import { PaymentExecutorClient } from "@zk-payroll/sdk";
+
+const client = new PaymentExecutorClient(server, "CCONTRACT_ID...");
+
+// Execute immediate payment
+const execResult = await client.execute({
+  recipient: "GPAYEE...",
+  amount: 1000n,
+  asset: "CNATIVE...",
+  memo: "monthly salary",
+}, signer);
+console.log("TxHash:", execResult.txHash);
+
+// Schedule payment
+const scheduleResult = await client.schedule({
+  recipient: "GPAYEE...",
+  amount: 500n,
+  asset: "CNATIVE...",
+  executeAt: Math.floor(Date.now() / 1000) + 86400,
+  memo: "bonus",
+}, signer);
+
+// Cancel scheduled payment
+await client.cancel(scheduleResult.paymentId, signer);
+
+// List pending payments
+const pending = await client.getPendingPayments("GEMPLOYER...", 0n, 20, signer);
+```
 
 ### Basic Proof Generation
 

--- a/packages/core/src/clients/PaymentExecutorClient.ts
+++ b/packages/core/src/clients/PaymentExecutorClient.ts
@@ -1,0 +1,160 @@
+import { rpc, xdr, nativeToScVal, Address, Keypair, Networks } from "@stellar/stellar-sdk";
+import { BaseContractWrapper } from "../adapters/BaseContractWrapper";
+import {
+  ClientOptions,
+  ExecutePaymentRequest,
+  SchedulePaymentRequest,
+  ScheduledPayment,
+} from "./types";
+
+export interface ExecutePaymentResponse {
+  txHash: string;
+}
+
+export interface SchedulePaymentResponse {
+  paymentId: bigint;
+}
+
+export class PaymentExecutorClient extends BaseContractWrapper {
+  private readonly networkPassphrase: string;
+
+  constructor(
+    server: rpc.Server,
+    contractId: string,
+    options?: ClientOptions
+  ) {
+    super(server, contractId);
+    this.networkPassphrase = options?.networkPassphrase ?? Networks.TESTNET;
+  }
+
+  async execute(
+    request: ExecutePaymentRequest,
+    signer: Keypair,
+    network?: string
+  ): Promise<ExecutePaymentResponse> {
+    const args: xdr.ScVal[] = [
+      new Address(request.recipient).toScVal(),
+      nativeToScVal(request.amount, { type: "i128" }),
+      new Address(request.asset).toScVal(),
+      nativeToScVal(request.memo ?? "", { type: "string" }),
+    ];
+
+    const result = await this.invoke("execute", args, signer, network ?? this.networkPassphrase);
+    return { txHash: this.scValToHex(result) };
+  }
+
+  async schedule(
+    request: SchedulePaymentRequest,
+    signer: Keypair,
+    network?: string
+  ): Promise<SchedulePaymentResponse> {
+    const args: xdr.ScVal[] = [
+      new Address(request.recipient).toScVal(),
+      nativeToScVal(request.amount, { type: "i128" }),
+      new Address(request.asset).toScVal(),
+      nativeToScVal(request.executeAt, { type: "u64" }),
+      nativeToScVal(request.memo ?? "", { type: "string" }),
+    ];
+
+    const result = await this.invoke("schedule", args, signer, network ?? this.networkPassphrase);
+    return { paymentId: this.scValToBigInt(result) };
+  }
+
+  async cancel(
+    paymentId: bigint,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [nativeToScVal(paymentId, { type: "u64" })];
+    await this.invoke("cancel", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async getScheduledPayment(
+    paymentId: bigint,
+    signer: Keypair,
+    network?: string
+  ): Promise<ScheduledPayment> {
+    const args: xdr.ScVal[] = [nativeToScVal(paymentId, { type: "u64" })];
+    const result = await this.invoke("get_scheduled_payment", args, signer, network ?? this.networkPassphrase);
+    return this.decodeScheduledPayment(result);
+  }
+
+  async getPendingPayments(
+    employer: string,
+    start: bigint,
+    limit: number,
+    signer: Keypair,
+    network?: string
+  ): Promise<ScheduledPayment[]> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      nativeToScVal(start, { type: "u64" }),
+      nativeToScVal(limit, { type: "u32" }),
+    ];
+
+    const result = await this.invoke("get_pending_payments", args, signer, network ?? this.networkPassphrase);
+    return this.decodeScheduledPaymentVec(result);
+  }
+
+  async getPaymentCount(
+    employer: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<number> {
+    const args: xdr.ScVal[] = [new Address(employer).toScVal()];
+    const result = await this.invoke("get_payment_count", args, signer, network ?? this.networkPassphrase);
+    return Number(result.u32());
+  }
+
+  private decodeScheduledPayment(scVal: xdr.ScVal): ScheduledPayment {
+    const map = scVal.map();
+    if (!map) {
+      throw new Error("Expected scvMap for ScheduledPayment");
+    }
+
+    const entries: Record<string, xdr.ScVal> = {};
+    for (const entry of map) {
+      const key = entry.key().sym()?.toString() ?? "";
+      entries[key] = entry.val();
+    }
+
+    return {
+      id: this.scValToBigInt(entries.id),
+      employer: Address.fromScVal(entries.employer).toString(),
+      recipient: Address.fromScVal(entries.recipient).toString(),
+      amount: this.scValToBigInt(entries.amount),
+      asset: Address.fromScVal(entries.asset).toString(),
+      executeAt: Number(this.scValToBigInt(entries.execute_at)),
+      memo: entries.memo?.str()?.toString() ?? "",
+      executed: entries.executed?.b() ?? false,
+      cancelled: entries.cancelled?.b() ?? false,
+      createdAt: Number(this.scValToBigInt(entries.created_at)),
+    };
+  }
+
+  private decodeScheduledPaymentVec(scVal: xdr.ScVal): ScheduledPayment[] {
+    const vec = scVal.vec();
+    if (!vec) return [];
+    return vec.map((v) => this.decodeScheduledPayment(v));
+  }
+
+  private scValToHex(scVal: xdr.ScVal): string {
+    const bytes = scVal.bytes();
+    if (bytes) return Buffer.from(bytes).toString("hex");
+    const str = scVal.str();
+    if (str) return str.toString();
+    return "";
+  }
+
+  private scValToBigInt(scVal: xdr.ScVal): bigint {
+    const i128 = scVal.i128();
+    if (i128) {
+      const hi = BigInt(i128.hi());
+      const lo = BigInt(i128.lo());
+      return (hi << 64n) | lo;
+    }
+    const u64 = scVal.u64();
+    if (u64) return BigInt(u64);
+    return 0n;
+  }
+}

--- a/packages/core/src/clients/PayrollRegistryClient.ts
+++ b/packages/core/src/clients/PayrollRegistryClient.ts
@@ -1,0 +1,159 @@
+import { rpc, xdr, nativeToScVal, Address, Keypair, Networks } from "@stellar/stellar-sdk";
+import { BaseContractWrapper } from "../adapters/BaseContractWrapper";
+import { ClientOptions, RegistryEntry, RegisterRequest, UpdateRegistryRequest } from "./types";
+
+export class PayrollRegistryClient extends BaseContractWrapper {
+  private readonly networkPassphrase: string;
+
+  constructor(
+    server: rpc.Server,
+    contractId: string,
+    options?: ClientOptions
+  ) {
+    super(server, contractId);
+    this.networkPassphrase = options?.networkPassphrase ?? Networks.TESTNET;
+  }
+
+  async register(
+    request: RegisterRequest,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [
+      new Address(request.employer).toScVal(),
+      new Address(request.employee).toScVal(),
+      nativeToScVal(request.salary, { type: "i128" }),
+      new Address(request.token).toScVal(),
+      nativeToScVal(request.metadata ?? "", { type: "string" }),
+    ];
+
+    await this.invoke("register", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async getRegistry(
+    employer: string,
+    employee: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<RegistryEntry> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+    ];
+
+    const result = await this.invoke("get_registry", args, signer, network ?? this.networkPassphrase);
+    return this.decodeRegistryEntry(result);
+  }
+
+  async updateRegistry(
+    request: UpdateRegistryRequest,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [
+      new Address(request.employer).toScVal(),
+      new Address(request.employee).toScVal(),
+      nativeToScVal(request.salary, { type: "i128" }),
+    ];
+
+    await this.invoke("update_registry", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async deactivateRegistry(
+    employer: string,
+    employee: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+    ];
+
+    await this.invoke("deactivate_registry", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async getEmployeeCount(
+    employer: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<number> {
+    const args: xdr.ScVal[] = [new Address(employer).toScVal()];
+    const result = await this.invoke("get_employee_count", args, signer, network ?? this.networkPassphrase);
+    return Number(result.u32());
+  }
+
+  async getEmployees(
+    employer: string,
+    start: number,
+    limit: number,
+    signer: Keypair,
+    network?: string
+  ): Promise<string[]> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      nativeToScVal(start, { type: "u32" }),
+      nativeToScVal(limit, { type: "u32" }),
+    ];
+
+    const result = await this.invoke("get_employees", args, signer, network ?? this.networkPassphrase);
+    return this.decodeAddressVec(result);
+  }
+
+  async registryExists(
+    employer: string,
+    employee: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<boolean> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+    ];
+
+    const result = await this.invoke("registry_exists", args, signer, network ?? this.networkPassphrase);
+    return result.b() === true;
+  }
+
+  private decodeRegistryEntry(scVal: xdr.ScVal): RegistryEntry {
+    const map = scVal.map();
+    if (!map) {
+      throw new Error("Expected scvMap for RegistryEntry");
+    }
+
+    const entries: Record<string, xdr.ScVal> = {};
+    for (const entry of map) {
+      const key = entry.key().sym()?.toString() ?? "";
+      entries[key] = entry.val();
+    }
+
+    return {
+      employer: Address.fromScVal(entries.employer).toString(),
+      employee: Address.fromScVal(entries.employee).toString(),
+      salary: this.scValToBigInt(entries.salary),
+      token: Address.fromScVal(entries.token).toString(),
+      metadata: entries.metadata?.str()?.toString() ?? "",
+      active: entries.active?.b() ?? false,
+      createdAt: Number(entries.created_at?.u64() ?? 0n),
+      updatedAt: Number(entries.updated_at?.u64() ?? 0n),
+    };
+  }
+
+  private decodeAddressVec(scVal: xdr.ScVal): string[] {
+    const vec = scVal.vec();
+    if (!vec) return [];
+    return vec.map((v) => Address.fromScVal(v).toString());
+  }
+
+  private scValToBigInt(scVal: xdr.ScVal): bigint {
+    const i128 = scVal.i128();
+    if (i128) {
+      const hi = BigInt(i128.hi());
+      const lo = BigInt(i128.lo());
+      return (hi << 64n) | lo;
+    }
+    const u64 = scVal.u64();
+    if (u64) return BigInt(u64);
+    return 0n;
+  }
+}

--- a/packages/core/src/clients/ProofVerifierClient.ts
+++ b/packages/core/src/clients/ProofVerifierClient.ts
@@ -1,0 +1,150 @@
+import { rpc, xdr, nativeToScVal, Keypair, Networks } from "@stellar/stellar-sdk";
+import { BaseContractWrapper } from "../adapters/BaseContractWrapper";
+import { ClientOptions, ProofStruct, VerificationKeyInfo } from "./types";
+
+export class ProofVerifierClient extends BaseContractWrapper {
+  private readonly networkPassphrase: string;
+
+  constructor(
+    server: rpc.Server,
+    contractId: string,
+    options?: ClientOptions
+  ) {
+    super(server, contractId);
+    this.networkPassphrase = options?.networkPassphrase ?? Networks.TESTNET;
+  }
+
+  async verify(
+    proof: ProofStruct,
+    publicInputs: string[],
+    verificationKeyId: number,
+    signer: Keypair,
+    network?: string
+  ): Promise<boolean> {
+    const args: xdr.ScVal[] = [
+      this.encodeProofStruct(proof),
+      xdr.ScVal.scvVec(publicInputs.map((s) => nativeToScVal(s, { type: "bytes" }))),
+      nativeToScVal(verificationKeyId, { type: "u32" }),
+    ];
+
+    const result = await this.invoke("verify", args, signer, network ?? this.networkPassphrase);
+    return result.b() === true;
+  }
+
+  async addVerificationKey(
+    vk: string,
+    description: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<number> {
+    const args: xdr.ScVal[] = [
+      nativeToScVal(vk, { type: "bytes" }),
+      nativeToScVal(description, { type: "string" }),
+    ];
+
+    const result = await this.invoke("add_verification_key", args, signer, network ?? this.networkPassphrase);
+    return Number(result.u32());
+  }
+
+  async getVerificationKey(
+    id: number,
+    signer: Keypair,
+    network?: string
+  ): Promise<string> {
+    const args: xdr.ScVal[] = [nativeToScVal(id, { type: "u32" })];
+    const result = await this.invoke("get_verification_key", args, signer, network ?? this.networkPassphrase);
+    const bytes = result.bytes();
+    return bytes ? Buffer.from(bytes).toString("hex") : "";
+  }
+
+  async setActiveVerificationKey(
+    id: number,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [nativeToScVal(id, { type: "u32" })];
+    await this.invoke("set_active_verification_key", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async getActiveVerificationKeyId(
+    signer: Keypair,
+    network?: string
+  ): Promise<number> {
+    const result = await this.invoke("get_active_verification_key_id", [], signer, network ?? this.networkPassphrase);
+    return Number(result.u32());
+  }
+
+  async getVerificationKeyCount(
+    signer: Keypair,
+    network?: string
+  ): Promise<number> {
+    const result = await this.invoke("get_verification_key_count", [], signer, network ?? this.networkPassphrase);
+    return Number(result.u32());
+  }
+
+  async getVerificationKeyInfo(
+    id: number,
+    signer: Keypair,
+    network?: string
+  ): Promise<VerificationKeyInfo> {
+    const args: xdr.ScVal[] = [nativeToScVal(id, { type: "u32" })];
+    const result = await this.invoke("get_verification_key_info", args, signer, network ?? this.networkPassphrase);
+    return this.decodeVerificationKeyInfo(result);
+  }
+
+  private encodeProofStruct(proof: ProofStruct): xdr.ScVal {
+    const piA = xdr.ScVal.scvVec(
+      proof.pi_a.map((s) => nativeToScVal(s, { type: "string" }))
+    );
+    const piB = xdr.ScVal.scvVec(
+      proof.pi_b.map((pair) =>
+        xdr.ScVal.scvVec(pair.map((s) => nativeToScVal(s, { type: "string" })))
+      )
+    );
+    const piC = xdr.ScVal.scvVec(
+      proof.pi_c.map((s) => nativeToScVal(s, { type: "string" }))
+    );
+    const publicSignals = xdr.ScVal.scvVec(
+      proof.publicSignals.map((s) => nativeToScVal(s, { type: "string" }))
+    );
+
+    return xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({
+        key: nativeToScVal("pi_a", { type: "symbol" }),
+        val: piA,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal("pi_b", { type: "symbol" }),
+        val: piB,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal("pi_c", { type: "symbol" }),
+        val: piC,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal("public_signals", { type: "symbol" }),
+        val: publicSignals,
+      }),
+    ]);
+  }
+
+  private decodeVerificationKeyInfo(scVal: xdr.ScVal): VerificationKeyInfo {
+    const map = scVal.map();
+    if (!map) {
+      throw new Error("Expected scvMap for VerificationKeyInfo");
+    }
+
+    const entries: Record<string, xdr.ScVal> = {};
+    for (const entry of map) {
+      const key = entry.key().sym()?.toString() ?? "";
+      entries[key] = entry.val();
+    }
+
+    const vkBytes = entries.key?.bytes();
+    return {
+      id: Number(entries.id?.u32() ?? 0),
+      description: entries.description?.str()?.toString() ?? "",
+      key: vkBytes ? Buffer.from(vkBytes).toString("hex") : "",
+    };
+  }
+}

--- a/packages/core/src/clients/SalaryCommitmentClient.ts
+++ b/packages/core/src/clients/SalaryCommitmentClient.ts
@@ -1,0 +1,216 @@
+import { rpc, xdr, nativeToScVal, Address, Keypair, Networks } from "@stellar/stellar-sdk";
+import { BaseContractWrapper } from "../adapters/BaseContractWrapper";
+import {
+  ClientOptions,
+  CommitmentEntry,
+  CommitRequest,
+  BatchCommitItem,
+  ProofStruct,
+} from "./types";
+
+export class SalaryCommitmentClient extends BaseContractWrapper {
+  private readonly networkPassphrase: string;
+
+  constructor(
+    server: rpc.Server,
+    contractId: string,
+    options?: ClientOptions
+  ) {
+    super(server, contractId);
+    this.networkPassphrase = options?.networkPassphrase ?? Networks.TESTNET;
+  }
+
+  async commit(
+    request: CommitRequest,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [
+      new Address(request.employer).toScVal(),
+      new Address(request.employee).toScVal(),
+      nativeToScVal(request.commitmentHash, { type: "bytes" }),
+      nativeToScVal(request.cycleId, { type: "u64" }),
+    ];
+
+    await this.invoke("commit", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async getCommitment(
+    employer: string,
+    employee: string,
+    cycleId: bigint,
+    signer: Keypair,
+    network?: string
+  ): Promise<CommitmentEntry> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+      nativeToScVal(cycleId, { type: "u64" }),
+    ];
+
+    const result = await this.invoke("get_commitment", args, signer, network ?? this.networkPassphrase);
+    return this.decodeCommitmentEntry(result);
+  }
+
+  async batchCommit(
+    employer: string,
+    commitments: BatchCommitItem[],
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const commitVec = xdr.ScVal.scvVec(
+      commitments.map((item) =>
+        xdr.ScVal.scvMap([
+          new xdr.ScMapEntry({
+            key: nativeToScVal("employee", { type: "symbol" }),
+            val: new Address(item.employee).toScVal(),
+          }),
+          new xdr.ScMapEntry({
+            key: nativeToScVal("commitment_hash", { type: "symbol" }),
+            val: nativeToScVal(item.commitmentHash, { type: "bytes" }),
+          }),
+          new xdr.ScMapEntry({
+            key: nativeToScVal("cycle_id", { type: "symbol" }),
+            val: nativeToScVal(item.cycleId, { type: "u64" }),
+          }),
+        ])
+      )
+    );
+
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      commitVec,
+    ];
+
+    await this.invoke("batch_commit", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async verifyCommitment(
+    employer: string,
+    employee: string,
+    cycleId: bigint,
+    proof: ProofStruct,
+    signer: Keypair,
+    network?: string
+  ): Promise<boolean> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+      nativeToScVal(cycleId, { type: "u64" }),
+      this.encodeProofStruct(proof),
+    ];
+
+    const result = await this.invoke("verify_commitment", args, signer, network ?? this.networkPassphrase);
+    return result.b() === true;
+  }
+
+  async revealSalary(
+    employer: string,
+    employee: string,
+    cycleId: bigint,
+    actualAmount: bigint,
+    signer: Keypair,
+    network?: string
+  ): Promise<void> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+      nativeToScVal(cycleId, { type: "u64" }),
+      nativeToScVal(actualAmount, { type: "i128" }),
+    ];
+
+    await this.invoke("reveal_salary", args, signer, network ?? this.networkPassphrase);
+  }
+
+  async getCommitmentCount(
+    employer: string,
+    employee: string,
+    signer: Keypair,
+    network?: string
+  ): Promise<number> {
+    const args: xdr.ScVal[] = [
+      new Address(employer).toScVal(),
+      new Address(employee).toScVal(),
+    ];
+
+    const result = await this.invoke("get_commitment_count", args, signer, network ?? this.networkPassphrase);
+    return Number(result.u32());
+  }
+
+  private decodeCommitmentEntry(scVal: xdr.ScVal): CommitmentEntry {
+    const map = scVal.map();
+    if (!map) {
+      throw new Error("Expected scvMap for CommitmentEntry");
+    }
+
+    const entries: Record<string, xdr.ScVal> = {};
+    for (const entry of map) {
+      const key = entry.key().sym()?.toString() ?? "";
+      entries[key] = entry.val();
+    }
+
+    return {
+      employer: Address.fromScVal(entries.employer).toString(),
+      employee: Address.fromScVal(entries.employee).toString(),
+      commitmentHash: this.scValToHex(entries.commitment_hash),
+      cycleId: this.scValToBigInt(entries.cycle_id),
+      createdAt: Number(this.scValToBigInt(entries.created_at)),
+      revealed: entries.revealed?.b() ?? false,
+      actualAmount: this.scValToBigInt(entries.actual_amount),
+    };
+  }
+
+  private encodeProofStruct(proof: ProofStruct): xdr.ScVal {
+    const piA = xdr.ScVal.scvVec(
+      proof.pi_a.map((s) => nativeToScVal(s, { type: "string" }))
+    );
+    const piB = xdr.ScVal.scvVec(
+      proof.pi_b.map((pair) =>
+        xdr.ScVal.scvVec(pair.map((s) => nativeToScVal(s, { type: "string" })))
+      )
+    );
+    const piC = xdr.ScVal.scvVec(
+      proof.pi_c.map((s) => nativeToScVal(s, { type: "string" }))
+    );
+    const publicSignals = xdr.ScVal.scvVec(
+      proof.publicSignals.map((s) => nativeToScVal(s, { type: "string" }))
+    );
+
+    return xdr.ScVal.scvMap([
+      new xdr.ScMapEntry({
+        key: nativeToScVal("pi_a", { type: "symbol" }),
+        val: piA,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal("pi_b", { type: "symbol" }),
+        val: piB,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal("pi_c", { type: "symbol" }),
+        val: piC,
+      }),
+      new xdr.ScMapEntry({
+        key: nativeToScVal("public_signals", { type: "symbol" }),
+        val: publicSignals,
+      }),
+    ]);
+  }
+
+  private scValToHex(scVal: xdr.ScVal): string {
+    const bytes = scVal.bytes();
+    if (bytes) return Buffer.from(bytes).toString("hex");
+    return "";
+  }
+
+  private scValToBigInt(scVal: xdr.ScVal): bigint {
+    const i128 = scVal.i128();
+    if (i128) {
+      const hi = BigInt(i128.hi());
+      const lo = BigInt(i128.lo());
+      return (hi << 64n) | lo;
+    }
+    const u64 = scVal.u64();
+    if (u64) return BigInt(u64);
+    return 0n;
+  }
+}

--- a/packages/core/src/clients/index.ts
+++ b/packages/core/src/clients/index.ts
@@ -1,0 +1,23 @@
+export { PayrollRegistryClient } from "./PayrollRegistryClient";
+export { SalaryCommitmentClient } from "./SalaryCommitmentClient";
+export { ProofVerifierClient } from "./ProofVerifierClient";
+export { PaymentExecutorClient } from "./PaymentExecutorClient";
+export type {
+  ExecutePaymentResponse,
+  SchedulePaymentResponse,
+} from "./PaymentExecutorClient";
+export type {
+  ClientOptions,
+  RegistryEntry,
+  RegisterRequest,
+  UpdateRegistryRequest,
+  CommitmentEntry,
+  CommitRequest,
+  BatchCommitItem,
+  ProofStruct,
+  VerifyProofRequest,
+  VerificationKeyInfo,
+  ExecutePaymentRequest,
+  SchedulePaymentRequest,
+  ScheduledPayment,
+} from "./types";

--- a/packages/core/src/clients/types.ts
+++ b/packages/core/src/clients/types.ts
@@ -1,0 +1,98 @@
+export interface ClientOptions {
+  networkPassphrase?: string;
+}
+
+export interface RegistryEntry {
+  employer: string;
+  employee: string;
+  salary: bigint;
+  token: string;
+  metadata: string;
+  active: boolean;
+  createdAt: number;
+  updatedAt: number;
+}
+
+export interface RegisterRequest {
+  employer: string;
+  employee: string;
+  salary: bigint;
+  token: string;
+  metadata?: string;
+}
+
+export interface UpdateRegistryRequest {
+  employer: string;
+  employee: string;
+  salary: bigint;
+}
+
+export interface CommitmentEntry {
+  employer: string;
+  employee: string;
+  commitmentHash: string;
+  cycleId: bigint;
+  createdAt: number;
+  revealed: boolean;
+  actualAmount: bigint;
+}
+
+export interface CommitRequest {
+  employer: string;
+  employee: string;
+  commitmentHash: string;
+  cycleId: bigint;
+}
+
+export interface BatchCommitItem {
+  employee: string;
+  commitmentHash: string;
+  cycleId: bigint;
+}
+
+export interface ProofStruct {
+  pi_a: [string, string];
+  pi_b: [[string, string], [string, string]];
+  pi_c: [string, string];
+  publicSignals: string[];
+}
+
+export interface VerifyProofRequest {
+  proof: ProofStruct;
+  publicInputs: string[];
+  verificationKeyId: number;
+}
+
+export interface VerificationKeyInfo {
+  id: number;
+  description: string;
+  key: string;
+}
+
+export interface ExecutePaymentRequest {
+  recipient: string;
+  amount: bigint;
+  asset: string;
+  memo?: string;
+}
+
+export interface SchedulePaymentRequest {
+  recipient: string;
+  amount: bigint;
+  asset: string;
+  executeAt: number;
+  memo?: string;
+}
+
+export interface ScheduledPayment {
+  id: bigint;
+  employer: string;
+  recipient: string;
+  amount: bigint;
+  asset: string;
+  executeAt: number;
+  memo: string;
+  executed: boolean;
+  cancelled: boolean;
+  createdAt: number;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,3 +39,6 @@ export * from "./adapters";
 export * from "./testing";
 export { TransactionWatcher } from "./events";
 export type { ConfirmationOptions, ConfirmationResult } from "./events";
+
+// ── Typed Contract Clients ───────────────────────────────────────────────────
+export * from "./clients";

--- a/packages/core/tests/typed-clients.test.ts
+++ b/packages/core/tests/typed-clients.test.ts
@@ -1,0 +1,606 @@
+import { rpc, xdr, Keypair, Networks, StrKey, nativeToScVal, Address } from "@stellar/stellar-sdk";
+import { PayrollRegistryClient } from "../src/clients/PayrollRegistryClient";
+import { SalaryCommitmentClient } from "../src/clients/SalaryCommitmentClient";
+import { ProofVerifierClient } from "../src/clients/ProofVerifierClient";
+import { PaymentExecutorClient } from "../src/clients/PaymentExecutorClient";
+import type { RegisterRequest, CommitRequest, BatchCommitItem, ProofStruct } from "../src/clients/types";
+
+const TEST_CONTRACT_ID = StrKey.encodeContract(Buffer.alloc(32, 1));
+const TEST_EMPLOYER = Keypair.random().publicKey();
+const TEST_EMPLOYEE = Keypair.random().publicKey();
+const TEST_TOKEN = StrKey.encodeContract(Buffer.alloc(32, 2));
+
+const MOCK_PROOF_STRUCT: ProofStruct = {
+  pi_a: ["1", "2"],
+  pi_b: [["3", "4"], ["5", "6"]],
+  pi_c: ["7", "8"],
+  publicSignals: ["abc", "def"],
+};
+
+function createMockServer(): rpc.Server {
+  return {} as rpc.Server;
+}
+
+function makeRegistryEntryScVal(overrides?: Partial<Record<string, xdr.ScVal>>): xdr.ScVal {
+  const defaults: Record<string, xdr.ScVal> = {
+    employer: new Address(TEST_EMPLOYER).toScVal(),
+    employee: new Address(TEST_EMPLOYEE).toScVal(),
+    salary: nativeToScVal(1000n, { type: "i128" }),
+    token: new Address(TEST_TOKEN).toScVal(),
+    metadata: nativeToScVal("engineering", { type: "string" }),
+    active: xdr.ScVal.scvBool(true),
+    created_at: nativeToScVal(100n, { type: "u64" }),
+    updated_at: nativeToScVal(200n, { type: "u64" }),
+  };
+  const merged = { ...defaults, ...overrides };
+  return xdr.ScVal.scvMap(
+    Object.entries(merged).map(([key, val]) =>
+      new xdr.ScMapEntry({
+        key: nativeToScVal(key, { type: "symbol" }),
+        val,
+      })
+    )
+  );
+}
+
+function makeCommitmentEntryScVal(overrides?: Partial<Record<string, xdr.ScVal>>): xdr.ScVal {
+  const defaults: Record<string, xdr.ScVal> = {
+    employer: new Address(TEST_EMPLOYER).toScVal(),
+    employee: new Address(TEST_EMPLOYEE).toScVal(),
+    commitment_hash: nativeToScVal(Buffer.from("abcd", "hex"), { type: "bytes" }),
+    cycle_id: nativeToScVal(1n, { type: "u64" }),
+    created_at: nativeToScVal(100n, { type: "u64" }),
+    revealed: xdr.ScVal.scvBool(false),
+    actual_amount: nativeToScVal(0n, { type: "i128" }),
+  };
+  const merged = { ...defaults, ...overrides };
+  return xdr.ScVal.scvMap(
+    Object.entries(merged).map(([key, val]) =>
+      new xdr.ScMapEntry({
+        key: nativeToScVal(key, { type: "symbol" }),
+        val,
+      })
+    )
+  );
+}
+
+function makeScheduledPaymentScVal(overrides?: Partial<Record<string, xdr.ScVal>>): xdr.ScVal {
+  const defaults: Record<string, xdr.ScVal> = {
+    id: nativeToScVal(42n, { type: "u64" }),
+    employer: new Address(TEST_EMPLOYER).toScVal(),
+    recipient: new Address(TEST_EMPLOYEE).toScVal(),
+    amount: nativeToScVal(500n, { type: "i128" }),
+    asset: new Address(TEST_TOKEN).toScVal(),
+    execute_at: nativeToScVal(1000n, { type: "u64" }),
+    memo: nativeToScVal("salary", { type: "string" }),
+    executed: xdr.ScVal.scvBool(false),
+    cancelled: xdr.ScVal.scvBool(false),
+    created_at: nativeToScVal(50n, { type: "u64" }),
+  };
+  const merged = { ...defaults, ...overrides };
+  return xdr.ScVal.scvMap(
+    Object.entries(merged).map(([key, val]) =>
+      new xdr.ScMapEntry({
+        key: nativeToScVal(key, { type: "symbol" }),
+        val,
+      })
+    )
+  );
+}
+
+// ── Testable subclasses ──────────────────────────────────────────────────────
+
+class TestablePayrollRegistryClient extends PayrollRegistryClient {
+  public invokeStub = jest.fn().mockResolvedValue(xdr.ScVal.scvVoid());
+
+  protected async invoke(method: string, args: xdr.ScVal[], signer: Keypair, network?: string): Promise<xdr.ScVal> {
+    return this.invokeStub(method, args, signer, network);
+  }
+}
+
+class TestableSalaryCommitmentClient extends SalaryCommitmentClient {
+  public invokeStub = jest.fn().mockResolvedValue(xdr.ScVal.scvVoid());
+
+  protected async invoke(method: string, args: xdr.ScVal[], signer: Keypair, network?: string): Promise<xdr.ScVal> {
+    return this.invokeStub(method, args, signer, network);
+  }
+}
+
+class TestableProofVerifierClient extends ProofVerifierClient {
+  public invokeStub = jest.fn().mockResolvedValue(xdr.ScVal.scvVoid());
+
+  protected async invoke(method: string, args: xdr.ScVal[], signer: Keypair, network?: string): Promise<xdr.ScVal> {
+    return this.invokeStub(method, args, signer, network);
+  }
+}
+
+class TestablePaymentExecutorClient extends PaymentExecutorClient {
+  public invokeStub = jest.fn().mockResolvedValue(xdr.ScVal.scvVoid());
+
+  protected async invoke(method: string, args: xdr.ScVal[], signer: Keypair, network?: string): Promise<xdr.ScVal> {
+    return this.invokeStub(method, args, signer, network);
+  }
+}
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PayrollRegistryClient Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("PayrollRegistryClient", () => {
+  let client: TestablePayrollRegistryClient;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    client = new TestablePayrollRegistryClient(createMockServer(), TEST_CONTRACT_ID);
+    signer = Keypair.random();
+  });
+
+  describe("constructor", () => {
+    it("creates a client with default TESTNET passphrase", () => {
+      expect(client).toBeInstanceOf(PayrollRegistryClient);
+    });
+
+    it("accepts a custom network passphrase", () => {
+      const custom = new TestablePayrollRegistryClient(createMockServer(), TEST_CONTRACT_ID, {
+        networkPassphrase: Networks.PUBLIC,
+      });
+      expect(custom).toBeInstanceOf(PayrollRegistryClient);
+    });
+  });
+
+  describe("register", () => {
+    const registerReq: RegisterRequest = {
+      employer: TEST_EMPLOYER,
+      employee: TEST_EMPLOYEE,
+      salary: 1000n,
+      token: TEST_TOKEN,
+      metadata: "engineering",
+    };
+
+    it("calls invoke with method name 'register'", async () => {
+      await client.register(registerReq, signer);
+      expect(client.invokeStub).toHaveBeenCalledTimes(1);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("register");
+    });
+
+    it("encodes five XDR arguments", async () => {
+      await client.register(registerReq, signer);
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(5);
+    });
+
+    it("defaults metadata to empty string when omitted", async () => {
+      const req: RegisterRequest = {
+        employer: TEST_EMPLOYER,
+        employee: TEST_EMPLOYEE,
+        salary: 1000n,
+        token: TEST_TOKEN,
+      };
+      await client.register(req, signer);
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args[4].str()).toBeDefined();
+    });
+  });
+
+  describe("getRegistry", () => {
+    it("calls invoke with method name 'get_registry'", async () => {
+      client.invokeStub.mockResolvedValue(makeRegistryEntryScVal());
+      await client.getRegistry(TEST_EMPLOYER, TEST_EMPLOYEE, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_registry");
+    });
+
+    it("returns a decoded RegistryEntry", async () => {
+      client.invokeStub.mockResolvedValue(makeRegistryEntryScVal());
+      const entry = await client.getRegistry(TEST_EMPLOYER, TEST_EMPLOYEE, signer);
+      expect(entry).toMatchObject({
+        salary: 1000n,
+        metadata: "engineering",
+        active: true,
+      });
+    });
+
+    it("throws on invalid ScVal", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvVoid());
+      await expect(
+        client.getRegistry(TEST_EMPLOYER, TEST_EMPLOYEE, signer)
+      ).rejects.toThrow("Expected scvMap for RegistryEntry");
+    });
+  });
+
+  describe("updateRegistry", () => {
+    it("calls invoke with method name 'update_registry'", async () => {
+      await client.updateRegistry({ employer: TEST_EMPLOYER, employee: TEST_EMPLOYEE, salary: 2000n }, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("update_registry");
+    });
+  });
+
+  describe("deactivateRegistry", () => {
+    it("calls invoke with method name 'deactivate_registry'", async () => {
+      await client.deactivateRegistry(TEST_EMPLOYER, TEST_EMPLOYEE, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("deactivate_registry");
+    });
+  });
+
+  describe("getEmployeeCount", () => {
+    it("calls invoke with method name 'get_employee_count'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(5, { type: "u32" }));
+      const count = await client.getEmployeeCount(TEST_EMPLOYER, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_employee_count");
+      expect(count).toBe(5);
+    });
+  });
+
+  describe("getEmployees", () => {
+    it("calls invoke with method name 'get_employees'", async () => {
+      client.invokeStub.mockResolvedValue(
+        xdr.ScVal.scvVec([new Address(TEST_EMPLOYEE).toScVal()])
+      );
+      const employees = await client.getEmployees(TEST_EMPLOYER, 0, 10, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_employees");
+      expect(employees).toHaveLength(1);
+      expect(employees[0]).toBe(TEST_EMPLOYEE);
+    });
+  });
+
+  describe("registryExists", () => {
+    it("calls invoke with method name 'registry_exists' and returns boolean", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvBool(true));
+      const exists = await client.registryExists(TEST_EMPLOYER, TEST_EMPLOYEE, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("registry_exists");
+      expect(exists).toBe(true);
+    });
+  });
+
+  describe("network passphrase", () => {
+    it("passes default TESTNET to invoke", async () => {
+      await client.register({ employer: TEST_EMPLOYER, employee: TEST_EMPLOYEE, salary: 1000n, token: TEST_TOKEN }, signer);
+      expect(client.invokeStub.mock.calls[0][3]).toBe(Networks.TESTNET);
+    });
+
+    it("passes custom network when provided", async () => {
+      await client.register({ employer: TEST_EMPLOYER, employee: TEST_EMPLOYEE, salary: 1000n, token: TEST_TOKEN }, signer, Networks.PUBLIC);
+      expect(client.invokeStub.mock.calls[0][3]).toBe(Networks.PUBLIC);
+    });
+
+    it("uses constructor-provided network passphrase", async () => {
+      const customClient = new TestablePayrollRegistryClient(createMockServer(), TEST_CONTRACT_ID, {
+        networkPassphrase: Networks.PUBLIC,
+      });
+      await customClient.register({ employer: TEST_EMPLOYER, employee: TEST_EMPLOYEE, salary: 1000n, token: TEST_TOKEN }, signer);
+      expect(customClient.invokeStub.mock.calls[0][3]).toBe(Networks.PUBLIC);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// SalaryCommitmentClient Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("SalaryCommitmentClient", () => {
+  let client: TestableSalaryCommitmentClient;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    client = new TestableSalaryCommitmentClient(createMockServer(), TEST_CONTRACT_ID);
+    signer = Keypair.random();
+  });
+
+  describe("constructor", () => {
+    it("creates a client", () => {
+      expect(client).toBeInstanceOf(SalaryCommitmentClient);
+    });
+  });
+
+  describe("commit", () => {
+    const commitReq: CommitRequest = {
+      employer: TEST_EMPLOYER,
+      employee: TEST_EMPLOYEE,
+      commitmentHash: Buffer.from("deadbeef", "hex").toString("hex"),
+      cycleId: 1n,
+    };
+
+    it("calls invoke with method name 'commit'", async () => {
+      await client.commit(commitReq, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("commit");
+    });
+
+    it("encodes four XDR arguments", async () => {
+      await client.commit(commitReq, signer);
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(4);
+    });
+  });
+
+  describe("getCommitment", () => {
+    it("calls invoke with method name 'get_commitment'", async () => {
+      client.invokeStub.mockResolvedValue(makeCommitmentEntryScVal());
+      await client.getCommitment(TEST_EMPLOYER, TEST_EMPLOYEE, 1n, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_commitment");
+    });
+
+    it("returns a decoded CommitmentEntry", async () => {
+      client.invokeStub.mockResolvedValue(makeCommitmentEntryScVal());
+      const entry = await client.getCommitment(TEST_EMPLOYER, TEST_EMPLOYEE, 1n, signer);
+      expect(entry).toMatchObject({
+        cycleId: 1n,
+        revealed: false,
+        actualAmount: 0n,
+      });
+    });
+  });
+
+  describe("batchCommit", () => {
+    const items: BatchCommitItem[] = [
+      { employee: TEST_EMPLOYEE, commitmentHash: "abcd", cycleId: 1n },
+    ];
+
+    it("calls invoke with method name 'batch_commit'", async () => {
+      await client.batchCommit(TEST_EMPLOYER, items, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("batch_commit");
+    });
+
+    it("encodes two XDR arguments (employer + vec)", async () => {
+      await client.batchCommit(TEST_EMPLOYER, items, signer);
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(2);
+    });
+  });
+
+  describe("verifyCommitment", () => {
+    it("calls invoke with method name 'verify_commitment'", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvBool(true));
+      const result = await client.verifyCommitment(TEST_EMPLOYER, TEST_EMPLOYEE, 1n, MOCK_PROOF_STRUCT, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("verify_commitment");
+      expect(result).toBe(true);
+    });
+  });
+
+  describe("revealSalary", () => {
+    it("calls invoke with method name 'reveal_salary'", async () => {
+      await client.revealSalary(TEST_EMPLOYER, TEST_EMPLOYEE, 1n, 1000n, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("reveal_salary");
+    });
+  });
+
+  describe("getCommitmentCount", () => {
+    it("calls invoke with method name 'get_commitment_count'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(3, { type: "u32" }));
+      const count = await client.getCommitmentCount(TEST_EMPLOYER, TEST_EMPLOYEE, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_commitment_count");
+      expect(count).toBe(3);
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// ProofVerifierClient Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("ProofVerifierClient", () => {
+  let client: TestableProofVerifierClient;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    client = new TestableProofVerifierClient(createMockServer(), TEST_CONTRACT_ID);
+    signer = Keypair.random();
+  });
+
+  describe("constructor", () => {
+    it("creates a client", () => {
+      expect(client).toBeInstanceOf(ProofVerifierClient);
+    });
+  });
+
+  describe("verify", () => {
+    it("calls invoke with method name 'verify'", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvBool(true));
+      const result = await client.verify(MOCK_PROOF_STRUCT, ["abc"], 1, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("verify");
+      expect(result).toBe(true);
+    });
+
+    it("encodes three XDR arguments", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvBool(true));
+      await client.verify(MOCK_PROOF_STRUCT, ["abc"], 1, signer);
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(3);
+    });
+  });
+
+  describe("addVerificationKey", () => {
+    it("calls invoke with method name 'add_verification_key'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(1, { type: "u32" }));
+      const id = await client.addVerificationKey("aabbcc", "test key", signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("add_verification_key");
+      expect(id).toBe(1);
+    });
+  });
+
+  describe("getVerificationKey", () => {
+    it("calls invoke with method name 'get_verification_key'", async () => {
+      const keyBytes = Buffer.from("deadbeef", "hex");
+      client.invokeStub.mockResolvedValue(nativeToScVal(keyBytes, { type: "bytes" }));
+      const key = await client.getVerificationKey(1, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_verification_key");
+      expect(key).toBe("deadbeef");
+    });
+  });
+
+  describe("setActiveVerificationKey", () => {
+    it("calls invoke with method name 'set_active_verification_key'", async () => {
+      await client.setActiveVerificationKey(1, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("set_active_verification_key");
+    });
+  });
+
+  describe("getActiveVerificationKeyId", () => {
+    it("calls invoke with method name 'get_active_verification_key_id'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(2, { type: "u32" }));
+      const id = await client.getActiveVerificationKeyId(signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_active_verification_key_id");
+      expect(id).toBe(2);
+    });
+  });
+
+  describe("getVerificationKeyCount", () => {
+    it("calls invoke with method name 'get_verification_key_count'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(3, { type: "u32" }));
+      const count = await client.getVerificationKeyCount(signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_verification_key_count");
+      expect(count).toBe(3);
+    });
+  });
+
+  describe("getVerificationKeyInfo", () => {
+    it("calls invoke with method name 'get_verification_key_info' and decodes response", async () => {
+      const infoScVal = xdr.ScVal.scvMap([
+        new xdr.ScMapEntry({ key: nativeToScVal("id", { type: "symbol" }), val: nativeToScVal(1, { type: "u32" }) }),
+        new xdr.ScMapEntry({ key: nativeToScVal("description", { type: "symbol" }), val: nativeToScVal("my key", { type: "string" }) }),
+        new xdr.ScMapEntry({ key: nativeToScVal("key", { type: "symbol" }), val: nativeToScVal(Buffer.from("ff00", "hex"), { type: "bytes" }) }),
+      ]);
+      client.invokeStub.mockResolvedValue(infoScVal);
+      const info = await client.getVerificationKeyInfo(1, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_verification_key_info");
+      expect(info).toMatchObject({ id: 1, description: "my key", key: "ff00" });
+    });
+  });
+
+  describe("error handling", () => {
+    it("rejects on invalid ScVal for getVerificationKeyInfo", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvVoid());
+      await expect(client.getVerificationKeyInfo(1, signer)).rejects.toThrow();
+    });
+  });
+});
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// PaymentExecutorClient Tests
+// ═══════════════════════════════════════════════════════════════════════════════
+
+describe("PaymentExecutorClient", () => {
+  let client: TestablePaymentExecutorClient;
+  let signer: Keypair;
+
+  beforeEach(() => {
+    client = new TestablePaymentExecutorClient(createMockServer(), TEST_CONTRACT_ID);
+    signer = Keypair.random();
+  });
+
+  describe("constructor", () => {
+    it("creates a client", () => {
+      expect(client).toBeInstanceOf(PaymentExecutorClient);
+    });
+  });
+
+  describe("execute", () => {
+    it("calls invoke with method name 'execute'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(Buffer.from("txhash", "hex"), { type: "bytes" }));
+      const result = await client.execute(
+        { recipient: TEST_EMPLOYEE, amount: 1000n, asset: TEST_TOKEN },
+        signer
+      );
+      expect(client.invokeStub.mock.calls[0][0]).toBe("execute");
+      expect(result).toHaveProperty("txHash");
+    });
+
+    it("encodes four XDR arguments", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(Buffer.from("00", "hex"), { type: "bytes" }));
+      await client.execute(
+        { recipient: TEST_EMPLOYEE, amount: 1000n, asset: TEST_TOKEN, memo: "bonus" },
+        signer
+      );
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(4);
+    });
+  });
+
+  describe("schedule", () => {
+    it("calls invoke with method name 'schedule'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(42n, { type: "u64" }));
+      const result = await client.schedule(
+        { recipient: TEST_EMPLOYEE, amount: 500n, asset: TEST_TOKEN, executeAt: 1000 },
+        signer
+      );
+      expect(client.invokeStub.mock.calls[0][0]).toBe("schedule");
+      expect(result.paymentId).toBe(42n);
+    });
+
+    it("encodes five XDR arguments", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(1n, { type: "u64" }));
+      await client.schedule(
+        { recipient: TEST_EMPLOYEE, amount: 500n, asset: TEST_TOKEN, executeAt: 1000, memo: "test" },
+        signer
+      );
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(5);
+    });
+  });
+
+  describe("cancel", () => {
+    it("calls invoke with method name 'cancel'", async () => {
+      await client.cancel(42n, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("cancel");
+    });
+
+    it("encodes one XDR argument", async () => {
+      await client.cancel(42n, signer);
+      const args: xdr.ScVal[] = client.invokeStub.mock.calls[0][1];
+      expect(args).toHaveLength(1);
+    });
+  });
+
+  describe("getScheduledPayment", () => {
+    it("calls invoke with method name 'get_scheduled_payment' and decodes response", async () => {
+      client.invokeStub.mockResolvedValue(makeScheduledPaymentScVal());
+      const payment = await client.getScheduledPayment(42n, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_scheduled_payment");
+      expect(payment).toMatchObject({
+        id: 42n,
+        amount: 500n,
+        executed: false,
+        cancelled: false,
+      });
+    });
+
+    it("throws on invalid ScVal", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvVoid());
+      await expect(client.getScheduledPayment(42n, signer)).rejects.toThrow("Expected scvMap for ScheduledPayment");
+    });
+  });
+
+  describe("getPendingPayments", () => {
+    it("calls invoke with method name 'get_pending_payments'", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvVec([makeScheduledPaymentScVal()]));
+      const payments = await client.getPendingPayments(TEST_EMPLOYER, 0n, 10, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_pending_payments");
+      expect(payments).toHaveLength(1);
+      expect(payments[0].id).toBe(42n);
+    });
+
+    it("returns empty array when no payments", async () => {
+      client.invokeStub.mockResolvedValue(xdr.ScVal.scvVec([]));
+      const payments = await client.getPendingPayments(TEST_EMPLOYER, 0n, 10, signer);
+      expect(payments).toEqual([]);
+    });
+  });
+
+  describe("getPaymentCount", () => {
+    it("calls invoke with method name 'get_payment_count'", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(7, { type: "u32" }));
+      const count = await client.getPaymentCount(TEST_EMPLOYER, signer);
+      expect(client.invokeStub.mock.calls[0][0]).toBe("get_payment_count");
+      expect(count).toBe(7);
+    });
+  });
+
+  describe("default network passphrase", () => {
+    it("uses TESTNET by default", async () => {
+      client.invokeStub.mockResolvedValue(nativeToScVal(1n, { type: "u64" }));
+      await client.schedule(
+        { recipient: TEST_EMPLOYEE, amount: 100n, asset: TEST_TOKEN, executeAt: 1000 },
+        signer
+      );
+      expect(client.invokeStub.mock.calls[0][3]).toBe(Networks.TESTNET);
+    });
+  });
+});


### PR DESCRIPTION
Closes #38

Summary:
Adds typed client wrappers for the core zk-payroll contracts so integrators can interact with contracts through the SDK without manually building contract calls.

Changes:

Added typed clients for:

- payroll_registry
- salary_commitment
- proof_verifier
- payment_executor

Features:

- Added reusable client constructors
- Added typed request/response models
- Standardized contract invocation patterns
- Added response decoding helpers
- Improved SDK ergonomics

Documentation:

- Added client usage examples
- Updated SDK documentation with supported contract wrappers

Tests:

- Covered client initialization
- Covered typed contract calls
- Covered response handling

Validation:

- Existing SDK behavior preserved
- Public API is consistent across clients