### PR TITLE
feat: benchmark memory usage for proof generation and artifact cachin…

### DIFF
--- a/packages/core/src/benchmarks/MemoryBenchmark.ts
+++ b/packages/core/src/benchmarks/MemoryBenchmark.ts
@@ -1,0 +1,203 @@
+/**
+ * Memory benchmarking utilities for the ZK Payroll SDK.
+ *
+ * Measures heap and ArrayBuffer pressure before and after each scenario so
+ * contributors can track regressions and guide optimisation work.
+ *
+ * ## Running with GC exposure (recommended)
+ * ```
+ * node --expose-gc node_modules/.bin/jest --config packages/core/jest.config.js \
+ *   tests/benchmarks/memory-benchmarks.test.ts --no-coverage --runInBand
+ * ```
+ *
+ * ## Browser-like environments
+ * Replace `sampleMemory()` with a call to `performance.memory` (Chrome / Edge
+ * DevTools) or the `measureUserAgentSpecificMemory()` API (cross-origin
+ * isolated contexts). The `BenchmarkResult` shape is identical.
+ */
+
+/** Snapshot of Node.js memory counters, all values in MiB. */
+export interface MemorySample {
+  heapUsedMB: number;
+  heapTotalMB: number;
+  externalMB: number;
+  rssMB: number;
+  arrayBuffersMB: number;
+}
+
+/** Stats produced by a single benchmark scenario. */
+export interface BenchmarkResult {
+  /** Short identifier — used as a key in baseline comparisons. */
+  scenario: string;
+  /** Human-readable sentence describing what was measured. */
+  description: string;
+  /** Number of measured iterations (excluding warmup). */
+  runs: number;
+  /** Average change in JS heap across measured runs. Can be negative after GC. */
+  avgHeapDeltaMB: number;
+  /** Highest heap observed across measured runs. */
+  peakHeapUsedMB: number;
+  /**
+   * Average change in externally allocated ArrayBuffers.
+   * This is the primary metric for artifact-load scenarios.
+   */
+  avgArrayBuffersDeltaMB: number;
+  /** Average change in external (off-V8-heap) memory. */
+  avgExternalDeltaMB: number;
+  /** Average wall-clock duration in milliseconds. */
+  avgDurationMs: number;
+}
+
+/** Baseline document written to disk after each benchmark run. */
+export interface BenchmarkBaseline {
+  generatedAt: string;
+  nodeVersion: string;
+  /** e.g. "darwin/arm64" */
+  platform: string;
+  results: BenchmarkResult[];
+}
+
+const MB = 1 / (1024 * 1024);
+
+/** Capture current process memory counters. */
+export function sampleMemory(): MemorySample {
+  const m = process.memoryUsage();
+  return {
+    heapUsedMB: m.heapUsed * MB,
+    heapTotalMB: m.heapTotal * MB,
+    externalMB: m.external * MB,
+    rssMB: m.rss * MB,
+    arrayBuffersMB: m.arrayBuffers * MB,
+  };
+}
+
+/** Nudge V8's GC if the process was started with --expose-gc. */
+export function gcHint(): void {
+  const g = global as unknown as { gc?: () => void };
+  if (typeof g.gc === "function") g.gc();
+}
+
+/**
+ * Runs a benchmark scenario and returns memory/timing statistics.
+ *
+ * @param scenario     - Short identifier (no spaces)
+ * @param description  - Human-readable description for the baseline table
+ * @param fn           - The operation to measure
+ * @param warmupRuns   - Pre-measurement runs to let V8 JIT and stabilise GC
+ * @param measuredRuns - Number of measured iterations for averaging
+ */
+export async function measureMemory(
+  scenario: string,
+  description: string,
+  fn: () => Promise<void> | void,
+  warmupRuns = 1,
+  measuredRuns = 3
+): Promise<BenchmarkResult> {
+  // Warmup
+  for (let i = 0; i < warmupRuns; i++) {
+    await fn();
+  }
+  gcHint();
+
+  const heapDeltas: number[] = [];
+  const abDeltas: number[] = [];
+  const externalDeltas: number[] = [];
+  const durations: number[] = [];
+  let peakHeap = 0;
+
+  for (let i = 0; i < measuredRuns; i++) {
+    gcHint();
+    const before = sampleMemory();
+    const t0 = Date.now();
+    await fn();
+    const after = sampleMemory();
+    const elapsed = Date.now() - t0;
+
+    heapDeltas.push(after.heapUsedMB - before.heapUsedMB);
+    abDeltas.push(after.arrayBuffersMB - before.arrayBuffersMB);
+    externalDeltas.push(after.externalMB - before.externalMB);
+    durations.push(elapsed);
+    peakHeap = Math.max(peakHeap, after.heapUsedMB);
+  }
+
+  const avg = (arr: number[]) => arr.reduce((a, b) => a + b, 0) / arr.length;
+
+  return {
+    scenario,
+    description,
+    runs: measuredRuns,
+    avgHeapDeltaMB: avg(heapDeltas),
+    peakHeapUsedMB: peakHeap,
+    avgArrayBuffersDeltaMB: avg(abDeltas),
+    avgExternalDeltaMB: avg(externalDeltas),
+    avgDurationMs: avg(durations),
+  };
+}
+
+/**
+ * Wraps a list of results with environment metadata for archival.
+ */
+export function captureBaseline(results: BenchmarkResult[]): BenchmarkBaseline {
+  return {
+    generatedAt: new Date().toISOString(),
+    nodeVersion: process.version,
+    platform: `${process.platform}/${process.arch}`,
+    results,
+  };
+}
+
+/**
+ * Renders a contributor-friendly ASCII table from a baseline document.
+ *
+ * ```
+ * ---------------------------+-----------------------------------+...
+ *  Scenario                  | Description                       |...
+ * ---------------------------+-----------------------------------+...
+ *  cold_artifact_small       | Cold: 500 KB wasm + 1 MB zkey     |...
+ * ```
+ */
+export function formatTable(baseline: BenchmarkBaseline): string {
+  const headers = [
+    "Scenario",
+    "Description",
+    "Heap Δ MB",
+    "ABuf Δ MB",
+    "Ext Δ MB",
+    "Avg ms",
+    "Runs",
+  ];
+
+  const rows = baseline.results.map((r) => [
+    r.scenario,
+    r.description,
+    r.avgHeapDeltaMB.toFixed(2),
+    r.avgArrayBuffersDeltaMB.toFixed(2),
+    r.avgExternalDeltaMB.toFixed(2),
+    r.avgDurationMs.toFixed(0),
+    String(r.runs),
+  ]);
+
+  const widths = headers.map((h, i) =>
+    Math.max(h.length, ...rows.map((row) => row[i].length))
+  );
+
+  const cell = (s: string, w: number) => ` ${s.padEnd(w)} `;
+  const divider = widths.map((w) => "-".repeat(w + 2)).join("+");
+  const headerRow = headers.map((h, i) => cell(h, widths[i])).join("|");
+  const dataRows = rows.map((row) =>
+    row.map((c, i) => cell(c, widths[i])).join("|")
+  );
+
+  const lines = [
+    `Memory Benchmark Baseline — ${baseline.generatedAt}`,
+    `Node ${baseline.nodeVersion}  |  Platform: ${baseline.platform}`,
+    "",
+    divider,
+    headerRow,
+    divider,
+    ...dataRows,
+    divider,
+  ];
+
+  return lines.join("\n");
+}

--- a/packages/core/src/benchmarks/ProofMemoryScenarios.ts
+++ b/packages/core/src/benchmarks/ProofMemoryScenarios.ts
@@ -1,0 +1,231 @@
+/**
+ * Self-contained memory scenarios for ZK proof artifact loading and caching.
+ *
+ * Each function simulates the allocation patterns of `SnarkjsProofGenerator`
+ * without importing any application code, keeping the scenarios free from
+ * the errors.ts compile-error chain and compatible with isolated benchmarking.
+ *
+ * Sizes match realistic Groth16 circuit artifacts:
+ *   - wasm:  0.5 – 3 MB (circuit compiled to WebAssembly)
+ *   - zkey: 1 – 10 MB  (compressed proving key, often 50–200 MB in production)
+ */
+
+// ── Artifact size presets ────────────────────────────────────────────────────
+
+export interface ArtifactSizes {
+  wasmBytes: number;
+  zkeyBytes: number;
+}
+
+export const ARTIFACT_SIZES = {
+  /** Minimal circuit (unit-test scale). */
+  SMALL: { wasmBytes: 500_000, zkeyBytes: 1_000_000 } as ArtifactSizes,
+  /** Typical development circuit. */
+  MEDIUM: { wasmBytes: 2_000_000, zkeyBytes: 5_000_000 } as ArtifactSizes,
+  /** Large circuit — stresses memory pressure. */
+  LARGE: { wasmBytes: 3_000_000, zkeyBytes: 10_000_000 } as ArtifactSizes,
+} as const;
+
+// ── Internal cache types (mirrors SnarkjsProofGenerator internal state) ───────
+
+export interface ArtifactEntry {
+  wasm: ArrayBuffer;
+  zkey: Uint8Array;
+}
+
+export type ArtifactCache = Map<string, ArtifactEntry>;
+export type ProofCache = Map<string, string>;
+
+// ── Scenario helpers ──────────────────────────────────────────────────────────
+
+/**
+ * Allocates fresh circuit artifacts — simulates the first network fetch
+ * (cold cache). The returned buffers are held in memory by the caller so that
+ * V8 does not immediately GC them before measurement completes.
+ */
+export function simulateColdArtifactLoad(sizes: ArtifactSizes): ArtifactEntry {
+  return {
+    wasm: new ArrayBuffer(sizes.wasmBytes),
+    zkey: new Uint8Array(sizes.zkeyBytes),
+  };
+}
+
+/**
+ * Returns an artifact entry from an already-populated cache (warm cache).
+ * No buffer allocation occurs; only a Map lookup.
+ */
+export function simulateWarmArtifactLoad(
+  cache: ArtifactCache,
+  key = "circuit"
+): ArtifactEntry | undefined {
+  return cache.get(key);
+}
+
+/**
+ * Populates an ArtifactCache with one entry — the state after a successful
+ * first fetch has been stored.
+ */
+export function buildArtifactCache(
+  sizes: ArtifactSizes,
+  key = "circuit"
+): ArtifactCache {
+  const cache: ArtifactCache = new Map();
+  cache.set(key, {
+    wasm: new ArrayBuffer(sizes.wasmBytes),
+    zkey: new Uint8Array(sizes.zkeyBytes),
+  });
+  return cache;
+}
+
+/**
+ * Serialises a proof witness to JSON — mirrors `SnarkjsProofGenerator.witnessKey()`.
+ * @param extraFields - Additional padding fields to grow the witness object.
+ */
+export function encodeWitness(
+  recipient: string,
+  amount: bigint,
+  extraFields = 0
+): string {
+  const w: Record<string, string> = {
+    recipient,
+    amount: amount.toString(),
+    asset: "native",
+  };
+  for (let i = 0; i < extraFields; i++) {
+    w[`field_${i}`] = `value_${"x".repeat(16)}_${i}`;
+  }
+  return JSON.stringify(w);
+}
+
+/** Builds a minimal ProofPayload JSON string — returned by the proof cache. */
+export function buildProofJson(publicSignalsCount = 3): string {
+  const sigs = Array.from(
+    { length: publicSignalsCount },
+    (_, i) => String((i + 1) * 111_111_111)
+  );
+  return JSON.stringify({
+    proof: {
+      pi_a: ["1111111111111111111", "2222222222222222222"],
+      pi_b: [
+        ["3333333333333333333", "4444444444444444444"],
+        ["5555555555555555555", "6666666666666666666"],
+      ],
+      pi_c: ["7777777777777777777", "8888888888888888888"],
+      protocol: "groth16",
+      curve: "bn128",
+    },
+    publicSignals: sigs,
+  });
+}
+
+// ── Benchmark scenario functions ──────────────────────────────────────────────
+
+/**
+ * **Cold artifact load** — no cache exists.
+ * Allocates wasm + zkey buffers and stores them in the provided map.
+ */
+export async function coldArtifactLoad(
+  dest: ArtifactCache,
+  sizes: ArtifactSizes,
+  key = "circuit"
+): Promise<void> {
+  const entry = simulateColdArtifactLoad(sizes);
+  dest.set(key, entry);
+}
+
+/**
+ * **Warm artifact load** — cache is populated.
+ * Reads the existing entry; no new buffers are allocated.
+ */
+export async function warmArtifactLoad(
+  cache: ArtifactCache,
+  key = "circuit"
+): Promise<void> {
+  const entry = simulateWarmArtifactLoad(cache, key);
+  // Touch a field so V8 doesn't optimise the lookup away entirely.
+  void entry?.wasm.byteLength;
+}
+
+/**
+ * **Cold proof generation** — full cycle: artifact load → witness encode →
+ * proof compute (simulated) → result cache write.
+ */
+export async function coldProofGeneration(
+  artifactDest: ArtifactCache,
+  proofDest: ProofCache,
+  sizes: ArtifactSizes,
+  witnessExtraFields = 0,
+  key = "circuit"
+): Promise<void> {
+  // Step 1 — load artifacts (simulates axios.get)
+  await coldArtifactLoad(artifactDest, sizes, key);
+
+  // Step 2 — encode witness (mirrors SnarkjsProofGenerator.witnessKey)
+  const witnessKey = `proof:${encodeWitness("GALICE_FIXTURE", 1_000_000n, witnessExtraFields)}`;
+
+  // Step 3 — simulate groth16.fullProve (CPU-bound, but allocates output)
+  const proofJson = buildProofJson();
+
+  // Step 4 — cache the result (mirrors cache.set)
+  proofDest.set(witnessKey, proofJson);
+}
+
+/**
+ * **Warm proof generation** — cache hit path.
+ * Looks up the cached proof string and parses it (mirrors JSON.parse in
+ * `SnarkjsProofGenerator.generateProof`).
+ */
+export async function warmProofGeneration(
+  proofCache: ProofCache,
+  key?: string
+): Promise<void> {
+  const cacheKey = key ?? `proof:${encodeWitness("GALICE_FIXTURE", 1_000_000n)}`;
+  const cached = proofCache.get(cacheKey);
+  if (cached) {
+    JSON.parse(cached);
+  }
+}
+
+/**
+ * **Concurrent cold generation** — N calls in parallel.
+ * Simulates multiple SDK clients or concurrent API requests, each triggering
+ * a separate artifact allocation before the cache is shared.
+ */
+export async function concurrentColdGeneration(
+  concurrency: number,
+  sizes: ArtifactSizes
+): Promise<void> {
+  await Promise.all(
+    Array.from({ length: concurrency }, async (_, i) => {
+      const dest: ArtifactCache = new Map();
+      const proofs: ProofCache = new Map();
+      await coldProofGeneration(dest, proofs, sizes, 0, `circuit-${i}`);
+    })
+  );
+}
+
+/**
+ * **Batch proof generation** — repeated proof generation for a list of
+ * witnesses sharing a warm artifact cache.
+ */
+export async function batchProofGeneration(
+  batchSize: number,
+  sizes: ArtifactSizes
+): Promise<void> {
+  const artifactCache = buildArtifactCache(sizes);
+  const proofCache: ProofCache = new Map();
+
+  for (let i = 0; i < batchSize; i++) {
+    const wKey = `proof:${encodeWitness(`G_EMPLOYEE_${i}`, BigInt(i + 1) * 100_000n)}`;
+    if (proofCache.has(wKey)) {
+      // warm path
+      await warmProofGeneration(proofCache, wKey);
+    } else {
+      // cold proof (warm artifacts)
+      const proofJson = buildProofJson();
+      proofCache.set(wKey, proofJson);
+    }
+    // Artifacts are read from warm cache — no re-allocation
+    simulateWarmArtifactLoad(artifactCache);
+  }
+}

--- a/packages/core/src/benchmarks/index.ts
+++ b/packages/core/src/benchmarks/index.ts
@@ -1,0 +1,35 @@
+export {
+  sampleMemory,
+  gcHint,
+  measureMemory,
+  captureBaseline,
+  formatTable,
+} from "./MemoryBenchmark";
+
+export type {
+  MemorySample,
+  BenchmarkResult,
+  BenchmarkBaseline,
+} from "./MemoryBenchmark";
+
+export {
+  ARTIFACT_SIZES,
+  simulateColdArtifactLoad,
+  simulateWarmArtifactLoad,
+  buildArtifactCache,
+  encodeWitness,
+  buildProofJson,
+  coldArtifactLoad,
+  warmArtifactLoad,
+  coldProofGeneration,
+  warmProofGeneration,
+  concurrentColdGeneration,
+  batchProofGeneration,
+} from "./ProofMemoryScenarios";
+
+export type {
+  ArtifactSizes,
+  ArtifactEntry,
+  ArtifactCache,
+  ProofCache,
+} from "./ProofMemoryScenarios";

--- a/packages/core/tests/benchmarks/baseline.json
+++ b/packages/core/tests/benchmarks/baseline.json
@@ -1,0 +1,117 @@
+{
+  "generatedAt": "2026-06-28T13:16:40.072Z",
+  "nodeVersion": "v22.21.1",
+  "platform": "darwin/x64",
+  "results": [
+    {
+      "scenario": "cold_artifact_small",
+      "description": "Cold: 500 KB wasm + 1 MB zkey",
+      "runs": 3,
+      "avgHeapDeltaMB": 0.0037027994791666665,
+      "peakHeapUsedMB": 313.2908706665039,
+      "avgArrayBuffersDeltaMB": 1.430511474609375,
+      "avgExternalDeltaMB": 1.430524190266927,
+      "avgDurationMs": 0.3333333333333333
+    },
+    {
+      "scenario": "cold_artifact_medium",
+      "description": "Cold: 2 MB wasm + 5 MB zkey",
+      "runs": 3,
+      "avgHeapDeltaMB": 0.0021082560221354165,
+      "peakHeapUsedMB": 313.57275390625,
+      "avgArrayBuffersDeltaMB": 6.67572021484375,
+      "avgExternalDeltaMB": 6.67572021484375,
+      "avgDurationMs": 0
+    },
+    {
+      "scenario": "cold_artifact_large",
+      "description": "Cold: 3 MB wasm + 10 MB zkey",
+      "runs": 3,
+      "avgHeapDeltaMB": -0.013242085774739584,
+      "peakHeapUsedMB": 309.27085876464844,
+      "avgArrayBuffersDeltaMB": -9.377797444661459,
+      "avgExternalDeltaMB": -10.822499593098959,
+      "avgDurationMs": 9
+    },
+    {
+      "scenario": "warm_artifact_small",
+      "description": "Warm: Map lookup only, no new buffers",
+      "runs": 5,
+      "avgHeapDeltaMB": 0.00133514404296875,
+      "peakHeapUsedMB": 309.3749694824219,
+      "avgArrayBuffersDeltaMB": 0,
+      "avgExternalDeltaMB": 0,
+      "avgDurationMs": 0
+    },
+    {
+      "scenario": "cold_proof_small",
+      "description": "Cold proof: artifact load + witness encode + proof cache write",
+      "runs": 3,
+      "avgHeapDeltaMB": 0.00569915771484375,
+      "peakHeapUsedMB": 309.67938232421875,
+      "avgArrayBuffersDeltaMB": 1.430511474609375,
+      "avgExternalDeltaMB": 1.430511474609375,
+      "avgDurationMs": 0.6666666666666666
+    },
+    {
+      "scenario": "cold_proof_medium",
+      "description": "Cold proof: medium artifacts (2 MB wasm + 5 MB zkey)",
+      "runs": 3,
+      "avgHeapDeltaMB": 0.003448486328125,
+      "peakHeapUsedMB": 309.2256088256836,
+      "avgArrayBuffersDeltaMB": 6.67572021484375,
+      "avgExternalDeltaMB": 6.67572021484375,
+      "avgDurationMs": 2.3333333333333335
+    },
+    {
+      "scenario": "warm_proof",
+      "description": "Warm proof: JSON.parse of cached proof, no buffer allocation",
+      "runs": 5,
+      "avgHeapDeltaMB": 0.00211334228515625,
+      "peakHeapUsedMB": 309.3817825317383,
+      "avgArrayBuffersDeltaMB": 0,
+      "avgExternalDeltaMB": 0,
+      "avgDurationMs": 0
+    },
+    {
+      "scenario": "concurrent_cold_2",
+      "description": "2 concurrent cold proof generations (small artifacts)",
+      "runs": 3,
+      "avgHeapDeltaMB": 0.00823974609375,
+      "peakHeapUsedMB": 309.33628845214844,
+      "avgArrayBuffersDeltaMB": 2.86102294921875,
+      "avgExternalDeltaMB": 2.86102294921875,
+      "avgDurationMs": 0.6666666666666666
+    },
+    {
+      "scenario": "concurrent_cold_5",
+      "description": "5 concurrent cold proof generations (small artifacts)",
+      "runs": 3,
+      "avgHeapDeltaMB": -0.041259765625,
+      "peakHeapUsedMB": 309.5131149291992,
+      "avgArrayBuffersDeltaMB": 1.9073486328125,
+      "avgExternalDeltaMB": 7.152557373046875,
+      "avgDurationMs": 2
+    },
+    {
+      "scenario": "batch_20_warm_artifacts",
+      "description": "20 proofs, warm artifact cache, unique witnesses",
+      "runs": 3,
+      "avgHeapDeltaMB": 0.02680206298828125,
+      "peakHeapUsedMB": 309.5881805419922,
+      "avgArrayBuffersDeltaMB": 1.430511474609375,
+      "avgExternalDeltaMB": 1.430511474609375,
+      "avgDurationMs": 1.3333333333333333
+    },
+    {
+      "scenario": "batch_100_warm_artifacts",
+      "description": "100 proofs, warm artifact cache, unique witnesses",
+      "runs": 2,
+      "avgHeapDeltaMB": 0.12862777709960938,
+      "peakHeapUsedMB": 310.16915130615234,
+      "avgArrayBuffersDeltaMB": 1.430511474609375,
+      "avgExternalDeltaMB": 1.430511474609375,
+      "avgDurationMs": 2
+    }
+  ]
+}

--- a/packages/core/tests/benchmarks/memory-benchmarks.test.ts
+++ b/packages/core/tests/benchmarks/memory-benchmarks.test.ts
@@ -1,0 +1,351 @@
+/**
+ * Memory benchmarks for proof generation and artifact caching.
+ *
+ * These tests measure heap and ArrayBuffer pressure for key SDK operations and
+ * emit a contributor-friendly baseline table to stdout. Results are also
+ * written to tests/benchmarks/baseline.json so that future runs can detect
+ * regressions.
+ *
+ * ## Recommended invocation (enables GC hints for cleaner deltas)
+ * ```
+ * node --expose-gc node_modules/.bin/jest \
+ *   --config packages/core/jest.config.js \
+ *   tests/benchmarks/memory-benchmarks.test.ts \
+ *   --no-coverage --runInBand
+ * ```
+ *
+ * ## Understanding the metrics
+ * - **Heap Δ MB**  — change in V8 heap used. Can be negative after GC sweeps.
+ * - **ABuf Δ MB**  — change in externally allocated ArrayBuffers. This is the
+ *                    primary metric for artifact-load scenarios because wasm and
+ *                    zkey buffers live outside the V8 heap.
+ * - **Ext Δ MB**   — change in total external (off-V8-heap) memory.
+ * - **Avg ms**     — average wall-clock time per measured run.
+ */
+
+import * as fs from "fs";
+import * as path from "path";
+
+import {
+  measureMemory,
+  captureBaseline,
+  formatTable,
+  BenchmarkResult,
+  BenchmarkBaseline,
+} from "../../src/benchmarks/MemoryBenchmark";
+
+import {
+  ARTIFACT_SIZES,
+  ArtifactCache,
+  ProofCache,
+  buildArtifactCache,
+  coldArtifactLoad,
+  warmArtifactLoad,
+  coldProofGeneration,
+  warmProofGeneration,
+  concurrentColdGeneration,
+  batchProofGeneration,
+  encodeWitness,
+  buildProofJson,
+} from "../../src/benchmarks/ProofMemoryScenarios";
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+/** Write the baseline JSON to disk. Silently skips if the directory is
+ *  read-only (e.g., inside some CI sandbox configurations). */
+function persistBaseline(baseline: BenchmarkBaseline): void {
+  try {
+    const outPath = path.join(__dirname, "baseline.json");
+    fs.writeFileSync(outPath, JSON.stringify(baseline, null, 2) + "\n", "utf8");
+  } catch {
+    // Non-fatal — the baseline table is always printed to stdout regardless.
+  }
+}
+
+// ── Test suite ─────────────────────────────────────────────────────────────────
+
+describe("Memory benchmarks — proof generation and artifact caching", () => {
+  const results: BenchmarkResult[] = [];
+
+  // ── Artifact load: cold cache ───────────────────────────────────────────────
+
+  describe("artifact load", () => {
+    it("cold cache (small artifacts) — allocates wasm + zkey buffers", async () => {
+      const result = await measureMemory(
+        "cold_artifact_small",
+        "Cold: 500 KB wasm + 1 MB zkey",
+        async () => {
+          const dest: ArtifactCache = new Map();
+          await coldArtifactLoad(dest, ARTIFACT_SIZES.SMALL);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      // ArrayBuffer delta should be positive (we allocated real buffers)
+      expect(result.avgArrayBuffersDeltaMB + result.avgExternalDeltaMB).toBeGreaterThanOrEqual(0);
+      // Combined allocation should not exceed 50 MB (generous ceiling)
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+
+    it("cold cache (medium artifacts) — 2 MB wasm + 5 MB zkey", async () => {
+      const result = await measureMemory(
+        "cold_artifact_medium",
+        "Cold: 2 MB wasm + 5 MB zkey",
+        async () => {
+          const dest: ArtifactCache = new Map();
+          await coldArtifactLoad(dest, ARTIFACT_SIZES.MEDIUM);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+
+    it("cold cache (large artifacts) — 3 MB wasm + 10 MB zkey", async () => {
+      const result = await measureMemory(
+        "cold_artifact_large",
+        "Cold: 3 MB wasm + 10 MB zkey",
+        async () => {
+          const dest: ArtifactCache = new Map();
+          await coldArtifactLoad(dest, ARTIFACT_SIZES.LARGE);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+
+    it("warm cache (small) — no new buffer allocation on cache hit", async () => {
+      // Pre-populate cache before measuring
+      const cache = buildArtifactCache(ARTIFACT_SIZES.SMALL);
+
+      const result = await measureMemory(
+        "warm_artifact_small",
+        "Warm: Map lookup only, no new buffers",
+        async () => {
+          await warmArtifactLoad(cache);
+        },
+        2,
+        5
+      );
+
+      results.push(result);
+      // Warm path: external / arrayBuffers delta should be near zero.
+      // We assert < 2 MB to accommodate GC noise across environments.
+      const combinedDelta = Math.abs(result.avgArrayBuffersDeltaMB + result.avgExternalDeltaMB);
+      expect(combinedDelta).toBeLessThan(2);
+    });
+
+    it("warm cache uses significantly less memory than cold cache", async () => {
+      // Cold
+      const coldDest: ArtifactCache = new Map();
+      const coldResult = await measureMemory(
+        "cold_vs_warm_reference",
+        "Cold reference for warm comparison",
+        async () => {
+          await coldArtifactLoad(coldDest, ARTIFACT_SIZES.MEDIUM);
+        },
+        0,
+        1
+      );
+
+      // Warm — reuse the same cache from cold run
+      const warmCache = buildArtifactCache(ARTIFACT_SIZES.MEDIUM);
+      const warmResult = await measureMemory(
+        "warm_vs_cold_reference",
+        "Warm reference for cold comparison",
+        async () => {
+          await warmArtifactLoad(warmCache);
+        },
+        1,
+        3
+      );
+
+      // Combined cold (heap + external) should exceed warm by a meaningful margin
+      const coldPressure = coldResult.avgArrayBuffersDeltaMB + coldResult.avgExternalDeltaMB;
+      const warmPressure = warmResult.avgArrayBuffersDeltaMB + warmResult.avgExternalDeltaMB;
+      expect(coldPressure).toBeGreaterThan(warmPressure);
+    });
+  });
+
+  // ── Proof generation ────────────────────────────────────────────────────────
+
+  describe("proof generation", () => {
+    it("cold proof generation (small) — full cycle including artifact allocation", async () => {
+      const result = await measureMemory(
+        "cold_proof_small",
+        "Cold proof: artifact load + witness encode + proof cache write",
+        async () => {
+          const artifacts: ArtifactCache = new Map();
+          const proofs: ProofCache = new Map();
+          await coldProofGeneration(artifacts, proofs, ARTIFACT_SIZES.SMALL);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+      expect(result.avgDurationMs).toBeLessThan(500);
+    });
+
+    it("cold proof generation (medium) — 2 MB wasm + 5 MB zkey", async () => {
+      const result = await measureMemory(
+        "cold_proof_medium",
+        "Cold proof: medium artifacts (2 MB wasm + 5 MB zkey)",
+        async () => {
+          const artifacts: ArtifactCache = new Map();
+          const proofs: ProofCache = new Map();
+          await coldProofGeneration(artifacts, proofs, ARTIFACT_SIZES.MEDIUM);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+
+    it("warm proof generation — proof cache hit, no artifact re-allocation", async () => {
+      // Populate the proof cache before measuring
+      const warmProofCache: ProofCache = new Map();
+      const cacheKey = `proof:${encodeWitness("GALICE_FIXTURE", 1_000_000n)}`;
+      warmProofCache.set(cacheKey, buildProofJson());
+
+      const result = await measureMemory(
+        "warm_proof",
+        "Warm proof: JSON.parse of cached proof, no buffer allocation",
+        async () => {
+          await warmProofGeneration(warmProofCache, cacheKey);
+        },
+        2,
+        5
+      );
+
+      results.push(result);
+      // Warm proof path: no new ArrayBuffers
+      expect(Math.abs(result.avgArrayBuffersDeltaMB)).toBeLessThan(1);
+      expect(result.avgDurationMs).toBeLessThan(50);
+    });
+
+    it("warm proof generation uses less memory than cold generation", async () => {
+      // Cold
+      const coldResult = await measureMemory(
+        "cold_proof_vs_warm",
+        "Cold proof reference",
+        async () => {
+          const artifacts: ArtifactCache = new Map();
+          const proofs: ProofCache = new Map();
+          await coldProofGeneration(artifacts, proofs, ARTIFACT_SIZES.MEDIUM);
+        },
+        0,
+        1
+      );
+
+      // Warm
+      const warmCache: ProofCache = new Map();
+      const wKey = `proof:${encodeWitness("GALICE_FIXTURE", 1_000_000n)}`;
+      warmCache.set(wKey, buildProofJson());
+
+      const warmResult = await measureMemory(
+        "warm_proof_vs_cold",
+        "Warm proof reference",
+        async () => {
+          await warmProofGeneration(warmCache, wKey);
+        },
+        1,
+        3
+      );
+
+      // Cold allocates more external memory (wasm + zkey)
+      const coldExt = coldResult.avgArrayBuffersDeltaMB + coldResult.avgExternalDeltaMB;
+      const warmExt = warmResult.avgArrayBuffersDeltaMB + warmResult.avgExternalDeltaMB;
+      expect(coldExt).toBeGreaterThan(warmExt);
+    });
+  });
+
+  // ── Concurrent and batch scenarios ─────────────────────────────────────────
+
+  describe("concurrent and batch generation", () => {
+    it("2 concurrent cold generations — stable peak memory", async () => {
+      const result = await measureMemory(
+        "concurrent_cold_2",
+        "2 concurrent cold proof generations (small artifacts)",
+        async () => {
+          await concurrentColdGeneration(2, ARTIFACT_SIZES.SMALL);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+
+    it("5 concurrent cold generations — peak stays within safe ceiling", async () => {
+      const result = await measureMemory(
+        "concurrent_cold_5",
+        "5 concurrent cold proof generations (small artifacts)",
+        async () => {
+          await concurrentColdGeneration(5, ARTIFACT_SIZES.SMALL);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      // 5× small artifacts = 5 × 1.5 MB = 7.5 MB. Allow generous headroom.
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+
+    it("batch of 20 proofs — warm artifact cache, no redundant allocation", async () => {
+      const result = await measureMemory(
+        "batch_20_warm_artifacts",
+        "20 proofs, warm artifact cache, unique witnesses",
+        async () => {
+          await batchProofGeneration(20, ARTIFACT_SIZES.SMALL);
+        },
+        1,
+        3
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+      expect(result.avgDurationMs).toBeLessThan(1000);
+    });
+
+    it("batch of 100 proofs — stress test heap allocation", async () => {
+      const result = await measureMemory(
+        "batch_100_warm_artifacts",
+        "100 proofs, warm artifact cache, unique witnesses",
+        async () => {
+          await batchProofGeneration(100, ARTIFACT_SIZES.SMALL);
+        },
+        1,
+        2
+      );
+
+      results.push(result);
+      expect(result.peakHeapUsedMB).toBeLessThan(500);
+    });
+  });
+
+  // ── Baseline output ─────────────────────────────────────────────────────────
+
+  afterAll(() => {
+    const baseline = captureBaseline(results);
+    const table = formatTable(baseline);
+
+    // Print for contributors and CI logs
+    console.log("\n" + table + "\n");
+
+    // Persist to disk for future comparison
+    persistBaseline(baseline);
+  });
+});


### PR DESCRIPTION
Closes #39 
Closes #43 
Closes #51 
Closes #78 


## Summary 


Circuit artifact download with checksum verification
Adds CircuitArtifactDownloader with SHA-256 verification for wasm/zkey files. SnarkjsProofGenerator now accepts optional checksums config; a mismatch throws ArtifactChecksumError before the artifact reaches the proving system.

 Mock environment coverage for RPC failures and proof errors
Extends the testing layer with MockRpcEnvironment (fluent failure configurators, call history tracking), four typed error classes (RpcTimeoutError, MalformedResponseError, RejectedTransactionError, InvalidProofError), ErrorAssertions async helpers, and an unhappy-path example file covering all scenarios.

Deterministic fixture builders
Adds AccountFixtures, PaymentFixtures, ProofFixtures, and ResponseFixtures under src/testing/fixtures/. Named accounts (alice/bob/carol) derive stable Ed25519 keypairs from a SHA-256 seed so keys are identical across every machine and run. All builders accept partial overrides and ship with an example file documenting customisation patterns.

Memory benchmarks for proof generation and artifact caching
Adds MemoryBenchmark (wraps process.memoryUsage() with warmup, GC hints, and averaged runs) and ProofMemoryScenarios (cold/warm artifact load, cold/warm proof generation, concurrent and batch scenarios). 13 Jest tests assert relative invariants (warm < cold allocation) and write a contributor-friendly ASCII baseline table plus baseline.json for regression tracking.