### PR TITLE
docs: create release note template

### DIFF
--- a/.github/RELEASE_TEMPLATE.md
+++ b/.github/RELEASE_TEMPLATE.md
@@ -1,0 +1,33 @@
+<!-- 
+Release Note Guidelines:
+- Versioning: Follow Semantic Versioning (SemVer).
+  - MAJOR: Breaking changes (requires a Migration Guide).
+  - MINOR: New features, non-breaking.
+  - PATCH: Bug fixes.
+- Deprecations: Announce deprecations at least one minor version before removal. Provide an alternative.
+-->
+
+## 🚀 Features
+
+<!-- Example: * **PayrollService**: Add support for batch payments in a single transaction (#123) -->
+- 
+
+## 🐛 Bug Fixes
+
+<!-- Example: * **core**: Fix issue where proofs failed to generate on certain system architectures (#124) -->
+- 
+
+## ⚠️ Breaking Changes
+
+<!-- List any breaking changes. If this is a MAJOR release, you MUST include this section. -->
+<!-- Example: * **API**: The `legacyProofGenerator` has been removed. Use `SnarkjsProofGenerator` instead. -->
+- 
+
+## 🔄 Migrations & Deprecations
+
+<!-- 
+Provide migration steps for breaking changes or announce upcoming deprecations.
+Example: 
+* **Deprecation**: `PayrollContract.legacyDeposit()` is deprecated and will be removed in v2.0.0. Use `PayrollContract.deposit()` instead.
+-->
+- 


### PR DESCRIPTION
   ## Closes #80                                                                                                                                                                                                       
                                                                                                                                                                                                                        
   ### Summary                                                                                                                                                                                                         
   Established a repeatable release-note structure for SDK updates to help integrators adopt changes with less risk and confusion.                                                                                     
                                                                                                                                                                                                                        
   ### What Changed                                                                                                                                                                                                    
   - Created `.github/RELEASE_TEMPLATE.md` to serve as a standardized template when drafting GitHub releases.                                                                                                          
   - Included structured sections for Features, Bug Fixes, Breaking Changes, and Migrations.                                                                                                                           
   - Added hidden markdown comments to guide authors on SemVer alignment and deprecation policies, along with inline examples.                                                                                         
                                                                                                                                                                                                                        
   ### Key Design Decisions                                                                                                                                                                                            
   - Opted for a Markdown template (`RELEASE_TEMPLATE.md`) containing hidden HTML comments. This provides guidance to the release author in the editor without cluttering the final published release notes.           
                                                                                                                                                                                                                        
   ### Acceptance Criteria Checklist                                                                                                                                                                                   
   - [x] The template is ready for use in future releases                                                                                                                                                              
   - [x] It captures the most important upgrade information (breaking changes, migrations)                                                                                                                             
   - [x] It aligns with the existing release process (fits seamlessly into manual GitHub release drafting)  