### PR TITLE
feat: simulation helper, draft persistence, history filters, and redaction utilities

### DIFF
--- a/packages/core/src/draft/DraftSerializer.ts
+++ b/packages/core/src/draft/DraftSerializer.ts
@@ -1,0 +1,134 @@
+import { DraftExportResult, DraftImportResult, PayrollDraft, PayrollDraftEntry } from "./types";
+
+const CURRENT_DRAFT_VERSION = 1;
+
+function simpleChecksum(data: string): string {
+  let hash = 0;
+  for (let i = 0; i < data.length; i++) {
+    const char = data.charCodeAt(i);
+    hash = (hash << 5) - hash + char;
+    hash |= 0;
+  }
+  return Math.abs(hash).toString(16).padStart(8, "0");
+}
+
+function validateEntry(entry: unknown, index: number): string[] {
+  const warnings: string[] = [];
+  if (!entry || typeof entry !== "object") {
+    warnings.push(`Entry at index ${index} is not an object.`);
+    return warnings;
+  }
+
+  const e = entry as Record<string, unknown>;
+
+  if (!e.recipientId || typeof e.recipientId !== "string" || e.recipientId.trim() === "") {
+    warnings.push(`Entry ${index}: missing or empty recipientId.`);
+  }
+
+  const amount = BigInt(String(e.amount ?? "0"));
+  if (amount <= 0n) {
+    warnings.push(`Entry ${index}: amount must be a positive value.`);
+  }
+
+  if (!e.asset || typeof e.asset !== "string" || e.asset.trim() === "") {
+    warnings.push(`Entry ${index}: missing or empty asset.`);
+  }
+
+  return warnings;
+}
+
+/**
+ * Serializes a PayrollDraft to a portable JSON string with an integrity checksum.
+ *
+ * @example
+ * const { data, checksum } = exportDraft(myDraft);
+ * localStorage.setItem("draft", data);
+ */
+export function exportDraft(draft: PayrollDraft): DraftExportResult {
+  const payload: PayrollDraft = {
+    ...draft,
+    version: CURRENT_DRAFT_VERSION,
+    updatedAt: new Date().toISOString(),
+  };
+  const data = JSON.stringify(payload, null, 2);
+  return { data, checksum: simpleChecksum(data) };
+}
+
+/**
+ * Deserializes and validates a previously exported draft string.
+ *
+ * Throws if the data is not parseable or missing required top-level fields.
+ * Entry-level issues are returned as warnings rather than errors so the
+ * caller can decide whether to discard or surface them.
+ *
+ * @example
+ * const { draft, warnings } = importDraft(raw);
+ * if (warnings.length) console.warn(warnings);
+ */
+export function importDraft(raw: string, expectedChecksum?: string): DraftImportResult {
+  if (!raw || raw.trim() === "") {
+    throw new Error("Draft data is empty.");
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    throw new Error("Draft data is not valid JSON.");
+  }
+
+  if (!parsed || typeof parsed !== "object") {
+    throw new Error("Draft data must be a JSON object.");
+  }
+
+  const obj = parsed as Record<string, unknown>;
+
+  if (typeof obj.version !== "number") {
+    throw new Error("Draft is missing a numeric version field.");
+  }
+
+  if (!Array.isArray(obj.entries)) {
+    throw new Error("Draft is missing an entries array.");
+  }
+
+  if (expectedChecksum !== undefined && simpleChecksum(raw) !== expectedChecksum) {
+    throw new Error("Draft checksum mismatch — data may have been tampered with.");
+  }
+
+  const warnings: string[] = [];
+
+  if (obj.version > CURRENT_DRAFT_VERSION) {
+    warnings.push(
+      `Draft version ${obj.version} is newer than the SDK supports (v${CURRENT_DRAFT_VERSION}). Some fields may be ignored.`
+    );
+  }
+
+  const entries = obj.entries as unknown[];
+  for (let i = 0; i < entries.length; i++) {
+    warnings.push(...validateEntry(entries[i], i));
+  }
+
+  const draft: PayrollDraft = {
+    version: obj.version as number,
+    createdAt: typeof obj.createdAt === "string" ? obj.createdAt : new Date().toISOString(),
+    updatedAt: typeof obj.updatedAt === "string" ? obj.updatedAt : new Date().toISOString(),
+    label: typeof obj.label === "string" ? obj.label : undefined,
+    entries: entries as PayrollDraftEntry[],
+  };
+
+  return { draft, warnings };
+}
+
+/**
+ * Creates a new empty draft with sensible defaults.
+ */
+export function createDraft(label?: string): PayrollDraft {
+  const now = new Date().toISOString();
+  return {
+    version: CURRENT_DRAFT_VERSION,
+    createdAt: now,
+    updatedAt: now,
+    label,
+    entries: [],
+  };
+}

--- a/packages/core/src/draft/index.ts
+++ b/packages/core/src/draft/index.ts
@@ -1,0 +1,2 @@
+export { createDraft, exportDraft, importDraft } from "./DraftSerializer";
+export type { DraftExportResult, DraftImportResult, PayrollDraft, PayrollDraftEntry } from "./types";

--- a/packages/core/src/draft/types.ts
+++ b/packages/core/src/draft/types.ts
@@ -1,0 +1,24 @@
+export interface PayrollDraftEntry {
+  recipientId: string;
+  amount: string;
+  asset: string;
+  note?: string;
+}
+
+export interface PayrollDraft {
+  version: number;
+  createdAt: string;
+  updatedAt: string;
+  label?: string;
+  entries: PayrollDraftEntry[];
+}
+
+export interface DraftExportResult {
+  data: string;
+  checksum: string;
+}
+
+export interface DraftImportResult {
+  draft: PayrollDraft;
+  warnings: string[];
+}

--- a/packages/core/src/filters/HistoryFilterBuilder.ts
+++ b/packages/core/src/filters/HistoryFilterBuilder.ts
@@ -1,0 +1,122 @@
+import { HistoryFilter, HistoryQuery, PaginationOptions, PayrollStatus } from "./types";
+
+/**
+ * Fluent builder for composing typed payroll history queries.
+ *
+ * Filters compose additively — each call narrows the result set.
+ * Call build() to get an immutable HistoryQuery ready for your API layer.
+ *
+ * @example
+ * const query = new HistoryFilterBuilder()
+ *   .forEmployees(["emp_1", "emp_2"])
+ *   .forPeriod("2024-01-01", "2024-03-31")
+ *   .withStatuses(["completed"])
+ *   .paginate({ page: 1, limit: 25 })
+ *   .build();
+ */
+export class HistoryFilterBuilder {
+  private filter: HistoryFilter = {};
+
+  forEmployees(ids: string[]): this {
+    this.filter.employeeIds = [...(this.filter.employeeIds ?? []), ...ids];
+    return this;
+  }
+
+  forEmployee(id: string): this {
+    return this.forEmployees([id]);
+  }
+
+  forPeriod(start: string, end: string): this {
+    this.filter.periodStart = start;
+    this.filter.periodEnd = end;
+    return this;
+  }
+
+  periodFrom(start: string): this {
+    this.filter.periodStart = start;
+    return this;
+  }
+
+  periodTo(end: string): this {
+    this.filter.periodEnd = end;
+    return this;
+  }
+
+  withAssets(assets: string[]): this {
+    this.filter.assets = [...(this.filter.assets ?? []), ...assets];
+    return this;
+  }
+
+  withAsset(asset: string): this {
+    return this.withAssets([asset]);
+  }
+
+  withStatuses(statuses: PayrollStatus[]): this {
+    this.filter.statuses = [...(this.filter.statuses ?? []), ...statuses];
+    return this;
+  }
+
+  withStatus(status: PayrollStatus): this {
+    return this.withStatuses([status]);
+  }
+
+  paginate(options: PaginationOptions): this {
+    this.filter.pagination = { ...this.filter.pagination, ...options };
+    return this;
+  }
+
+  reset(): this {
+    this.filter = {};
+    return this;
+  }
+
+  build(): HistoryQuery {
+    const snapshot: HistoryFilter = JSON.parse(JSON.stringify(this.filter));
+    return {
+      filter: snapshot,
+      toParams() {
+        const params: Record<string, string | string[] | number | undefined> = {};
+
+        if (snapshot.employeeIds?.length) params.employeeIds = snapshot.employeeIds;
+        if (snapshot.periodStart) params.periodStart = snapshot.periodStart;
+        if (snapshot.periodEnd) params.periodEnd = snapshot.periodEnd;
+        if (snapshot.assets?.length) params.assets = snapshot.assets;
+        if (snapshot.statuses?.length) params.statuses = snapshot.statuses;
+        if (snapshot.pagination?.page !== undefined) params.page = snapshot.pagination.page;
+        if (snapshot.pagination?.limit !== undefined) params.limit = snapshot.pagination.limit;
+        if (snapshot.pagination?.cursor) params.cursor = snapshot.pagination.cursor;
+
+        return params;
+      },
+    };
+  }
+}
+
+/**
+ * Shorthand factories for common single-dimension filters.
+ */
+export const PayrollHistoryFilters = {
+  byEmployee(id: string): HistoryQuery {
+    return new HistoryFilterBuilder().forEmployee(id).build();
+  },
+
+  byEmployees(ids: string[]): HistoryQuery {
+    return new HistoryFilterBuilder().forEmployees(ids).build();
+  },
+
+  byPeriod(start: string, end: string): HistoryQuery {
+    return new HistoryFilterBuilder().forPeriod(start, end).build();
+  },
+
+  byStatus(status: PayrollStatus): HistoryQuery {
+    return new HistoryFilterBuilder().withStatus(status).build();
+  },
+
+  byStatuses(statuses: PayrollStatus[]): HistoryQuery {
+    return new HistoryFilterBuilder().withStatuses(statuses).build();
+  },
+
+  byAsset(asset: string): HistoryQuery {
+    return new HistoryFilterBuilder().withAsset(asset).build();
+  },
+};

--- a/packages/core/src/filters/index.ts
+++ b/packages/core/src/filters/index.ts
@@ -1,0 +1,2 @@
+export { HistoryFilterBuilder, PayrollHistoryFilters } from "./HistoryFilterBuilder";
+export type { HistoryFilter, HistoryQuery, PaginationOptions, PayrollStatus } from "./types";

--- a/packages/core/src/filters/types.ts
+++ b/packages/core/src/filters/types.ts
@@ -1,0 +1,21 @@
+export type PayrollStatus = "pending" | "processing" | "completed" | "failed" | "cancelled";
+
+export interface PaginationOptions {
+  page?: number;
+  limit?: number;
+  cursor?: string;
+}
+
+export interface HistoryFilter {
+  employeeIds?: string[];
+  periodStart?: string;
+  periodEnd?: string;
+  assets?: string[];
+  statuses?: PayrollStatus[];
+  pagination?: PaginationOptions;
+}
+
+export interface HistoryQuery {
+  filter: HistoryFilter;
+  toParams(): Record<string, string | string[] | number | undefined>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -39,3 +39,6 @@ export * from "./clients";
 
 // ── Environment Sanity Checker ──────────────────────────────────────────────
 export * from "./sanity";
+
+// ── Transaction Simulation ──────────────────────────────────────────────────
+export * from "./simulation";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -45,3 +45,6 @@ export * from "./simulation";
 
 // ── Draft Persistence ───────────────────────────────────────────────────────
 export * from "./draft";
+
+// ── History Filter Builders ─────────────────────────────────────────────────
+export * from "./filters";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -48,3 +48,6 @@ export * from "./draft";
 
 // ── History Filter Builders ─────────────────────────────────────────────────
 export * from "./filters";
+
+// ── Redaction Utilities ─────────────────────────────────────────────────────
+export * from "./redaction";

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -42,3 +42,6 @@ export * from "./sanity";
 
 // ── Transaction Simulation ──────────────────────────────────────────────────
 export * from "./simulation";
+
+// ── Draft Persistence ───────────────────────────────────────────────────────
+export * from "./draft";

--- a/packages/core/src/logging/SdkLogger.ts
+++ b/packages/core/src/logging/SdkLogger.ts
@@ -35,19 +35,12 @@ export function createHookLogger(hook: LoggerHook): SdkLogger {
 }
 
 /**
- * Fields that must never appear in log output.
- * The SDK redacts these from context objects automatically.
- */
-const SENSITIVE_FIELDS = new Set(["recipient", "amount", "witness", "privateKey", "adminKey"]);
-
-/**
  * Returns a shallow copy of `context` with sensitive field values replaced by `"[redacted]"`.
  * Safe to call on any context object before passing to a logger.
+ *
+ * Delegates to the redaction module so the sensitive-field list stays in one place.
  */
 export function redactSensitive(context: Record<string, unknown>): Record<string, unknown> {
-  const result: Record<string, unknown> = {};
-  for (const [key, value] of Object.entries(context)) {
-    result[key] = SENSITIVE_FIELDS.has(key) ? "[redacted]" : value;
-  }
-  return result;
+  const { redactObject } = require("../redaction/RedactionEngine");
+  return redactObject(context).redacted as Record<string, unknown>;
 }

--- a/packages/core/src/redaction/RedactionEngine.ts
+++ b/packages/core/src/redaction/RedactionEngine.ts
@@ -1,0 +1,147 @@
+import { RedactionOptions, RedactionResult } from "./types";
+
+/** Fields that are always redacted regardless of caller options. */
+const DEFAULT_SENSITIVE_FIELDS = new Set([
+  "recipient",
+  "amount",
+  "witness",
+  "privateKey",
+  "adminKey",
+  "secret",
+  "password",
+  "token",
+  "mnemonic",
+  "seed",
+  "authorization",
+  "apiKey",
+  "api_key",
+  "accessToken",
+  "access_token",
+  "refreshToken",
+  "refresh_token",
+  "signingKey",
+]);
+
+function buildFieldSet(options: RedactionOptions = {}): Set<string> {
+  const set = new Set(DEFAULT_SENSITIVE_FIELDS);
+  for (const field of options.additionalFields ?? []) {
+    set.add(field);
+  }
+  return set;
+}
+
+function maskValue(value: string): string {
+  if (value.length <= 4) return "*".repeat(value.length);
+  return value.slice(0, 2) + "*".repeat(value.length - 4) + value.slice(-2);
+}
+
+function applyRedaction(value: unknown, options: RedactionOptions): unknown {
+  const mode = options.mode ?? "placeholder";
+  if (mode === "remove") return undefined;
+  if (mode === "mask") {
+    const str = typeof value === "string" ? value : String(value);
+    return maskValue(str);
+  }
+  return options.placeholder ?? "[redacted]";
+}
+
+/**
+ * Redacts sensitive fields from a plain object (shallow).
+ *
+ * Returns the cleaned object and a list of which keys were redacted so
+ * callers can log or audit what was stripped.
+ *
+ * @example
+ * const { redacted } = redactObject({ recipient: "G...", amount: 500n, txHash: "abc" });
+ * // { txHash: "abc", recipient: "[redacted]", amount: "[redacted]" }
+ */
+export function redactObject(
+  obj: Record<string, unknown>,
+  options: RedactionOptions = {}
+): RedactionResult<Record<string, unknown>> {
+  const sensitiveFields = buildFieldSet(options);
+  const result: Record<string, unknown> = {};
+  const fieldsRedacted: string[] = [];
+
+  for (const [key, value] of Object.entries(obj)) {
+    if (sensitiveFields.has(key)) {
+      const replacement = applyRedaction(value, options);
+      if (replacement !== undefined) {
+        result[key] = replacement;
+      }
+      fieldsRedacted.push(key);
+    } else {
+      result[key] = value;
+    }
+  }
+
+  return { redacted: result, fieldsRedacted };
+}
+
+/**
+ * Recursively redacts sensitive fields from a nested object.
+ *
+ * Arrays are traversed element-by-element. Primitive values at the
+ * top level are returned unchanged.
+ */
+export function redactDeep(
+  value: unknown,
+  options: RedactionOptions = {},
+  _fieldsRedacted: string[] = []
+): RedactionResult<unknown> {
+  const sensitiveFields = buildFieldSet(options);
+  const fieldsRedacted: string[] = _fieldsRedacted;
+
+  function walk(v: unknown): unknown {
+    if (Array.isArray(v)) {
+      return v.map((item) => walk(item));
+    }
+    if (v !== null && typeof v === "object") {
+      const out: Record<string, unknown> = {};
+      for (const [key, val] of Object.entries(v as Record<string, unknown>)) {
+        if (sensitiveFields.has(key)) {
+          const replacement = applyRedaction(val, options);
+          if (replacement !== undefined) {
+            out[key] = replacement;
+          }
+          if (!fieldsRedacted.includes(key)) fieldsRedacted.push(key);
+        } else {
+          out[key] = walk(val);
+        }
+      }
+      return out;
+    }
+    return v;
+  }
+
+  return { redacted: walk(value), fieldsRedacted };
+}
+
+/**
+ * Redacts sensitive values from an error's message and any attached context.
+ *
+ * Creates a new Error with the same constructor, sanitized message, and
+ * the original stack preserved so stack traces remain useful.
+ */
+export function redactError(error: Error, options: RedactionOptions = {}): Error {
+  const sensitiveFields = buildFieldSet(options);
+  const placeholder = options.placeholder ?? "[redacted]";
+
+  let message = error.message;
+  for (const field of sensitiveFields) {
+    const pattern = new RegExp(`(${field}\\s*[:=]\\s*)([^\\s,}]+)`, "gi");
+    message = message.replace(pattern, `$1${placeholder}`);
+  }
+
+  const sanitized = new (error.constructor as ErrorConstructor)(message);
+  sanitized.stack = error.stack;
+  return sanitized;
+}
+
+/**
+ * Returns the set of field names that the SDK considers sensitive by default.
+ * Consumers can use this to understand the baseline redaction behaviour.
+ */
+export function getDefaultSensitiveFields(): string[] {
+  return Array.from(DEFAULT_SENSITIVE_FIELDS);
+}

--- a/packages/core/src/redaction/index.ts
+++ b/packages/core/src/redaction/index.ts
@@ -1,0 +1,7 @@
+export {
+  getDefaultSensitiveFields,
+  redactDeep,
+  redactError,
+  redactObject,
+} from "./RedactionEngine";
+export type { RedactionMode, RedactionOptions, RedactionResult } from "./types";

--- a/packages/core/src/redaction/types.ts
+++ b/packages/core/src/redaction/types.ts
@@ -1,0 +1,15 @@
+export type RedactionMode = "mask" | "remove" | "placeholder";
+
+export interface RedactionOptions {
+  /** How to handle sensitive values. Defaults to "placeholder". */
+  mode?: RedactionMode;
+  /** Custom replacement string when mode is "placeholder". Defaults to "[redacted]". */
+  placeholder?: string;
+  /** Additional field names to treat as sensitive, merged with built-in defaults. */
+  additionalFields?: string[];
+}
+
+export interface RedactionResult<T> {
+  redacted: T;
+  fieldsRedacted: string[];
+}

--- a/packages/core/src/simulation/index.ts
+++ b/packages/core/src/simulation/index.ts
@@ -1,0 +1,2 @@
+export { simulatePayroll } from "./simulatePayroll";
+export type { SimulationFinding, SimulationInput, SimulationOptions, SimulationResult, SimulationStatus } from "./types";

--- a/packages/core/src/simulation/simulatePayroll.ts
+++ b/packages/core/src/simulation/simulatePayroll.ts
@@ -1,0 +1,98 @@
+import { PayrollValidation } from "../core/validation";
+import { SimulationFinding, SimulationInput, SimulationOptions, SimulationResult } from "./types";
+
+const BASE_FEE_STROOPS = 100n;
+const PROOF_FEE_STROOPS = 500n;
+
+function validateFields(input: SimulationInput): SimulationFinding[] {
+  const findings: SimulationFinding[] = [];
+  const result = PayrollValidation.validatePaymentParams(input);
+
+  for (const err of result.errors) {
+    findings.push({
+      code: `INVALID_${err.field.toUpperCase()}`,
+      severity: "error",
+      message: err.message,
+      field: err.field,
+    });
+  }
+
+  return findings;
+}
+
+function checkAmountWarnings(input: SimulationInput): SimulationFinding[] {
+  const findings: SimulationFinding[] = [];
+
+  if (input.amount > 0n && input.amount < 100n) {
+    findings.push({
+      code: "LOW_AMOUNT",
+      severity: "warning",
+      message: "Payment amount is very low (< 100 stroops). Confirm this is intentional.",
+      field: "amount",
+    });
+  }
+
+  if (input.amount > 1_000_000_000_000n) {
+    findings.push({
+      code: "HIGH_AMOUNT",
+      severity: "warning",
+      message: "Payment amount exceeds 1,000,000 XLM. Double-check before submitting.",
+      field: "amount",
+    });
+  }
+
+  return findings;
+}
+
+function checkAssetWarnings(input: SimulationInput): SimulationFinding[] {
+  const findings: SimulationFinding[] = [];
+
+  if (input.asset && input.asset !== "native" && !input.asset.startsWith("C")) {
+    findings.push({
+      code: "UNRECOGNIZED_ASSET_FORMAT",
+      severity: "warning",
+      message:
+        "Asset does not look like a native token or a Soroban contract ID (expected 'native' or a 'C...' address).",
+      field: "asset",
+    });
+  }
+
+  return findings;
+}
+
+function estimateFee(options: SimulationOptions = {}): bigint {
+  return options.skipProof !== false ? BASE_FEE_STROOPS : BASE_FEE_STROOPS + PROOF_FEE_STROOPS;
+}
+
+/**
+ * Runs a preflight simulation against the provided payment input without
+ * submitting a live transaction or generating a ZK proof.
+ *
+ * Use this before PayrollService.processPayment to surface validation
+ * failures and cost estimates early.
+ *
+ * @example
+ * const result = await simulatePayroll({ recipient, amount, asset });
+ * if (!result.canProceed) throw new Error(result.findings[0].message);
+ */
+export async function simulatePayroll(input: SimulationInput): Promise<SimulationResult> {
+  const { options = {} } = input;
+  const findings: SimulationFinding[] = [
+    ...validateFields(input),
+    ...checkAmountWarnings(input),
+    ...checkAssetWarnings(input),
+  ];
+
+  const hasErrors = findings.some((f) => f.severity === "error");
+  const hasWarnings = findings.some((f) => f.severity === "warning");
+
+  const status = hasErrors ? "error" : hasWarnings ? "warning" : "success";
+  const canProceed = !hasErrors;
+
+  return {
+    status,
+    findings,
+    canProceed,
+    estimatedFee: canProceed ? estimateFee(options) : undefined,
+  };
+}

--- a/packages/core/src/simulation/types.ts
+++ b/packages/core/src/simulation/types.ts
@@ -1,0 +1,26 @@
+import { PaymentParams } from "../types";
+
+export type SimulationStatus = "success" | "warning" | "error";
+
+export interface SimulationFinding {
+  code: string;
+  severity: "info" | "warning" | "error";
+  message: string;
+  field?: string;
+}
+
+export interface SimulationResult {
+  status: SimulationStatus;
+  findings: SimulationFinding[];
+  canProceed: boolean;
+  estimatedFee?: bigint;
+}
+
+export interface SimulationOptions {
+  /** Skip ZK proof generation during simulation (faster dry-run). Defaults to true. */
+  skipProof?: boolean;
+  /** Override the network for simulation purposes */
+  network?: string;
+}
+
+export type SimulationInput = PaymentParams & { options?: SimulationOptions };


### PR DESCRIPTION
## Summary

- **Issue #73** — Adds `simulatePayroll()` as a typed preflight helper that validates payment params, checks for amount/asset anomalies, and returns actionable findings with an estimated fee before touching the network or generating a ZK proof.
- **Issue #74** — Adds `exportDraft()`, `importDraft()`, and `createDraft()` for standard, checksum-verified serialization of payroll draft data; entry-level issues surface as warnings rather than hard failures.
- **Issue #75** — Adds `HistoryFilterBuilder` (fluent chainable API) and `PayrollHistoryFilters` (shorthand factories) covering employee, period, asset, and status dimensions, with a `toParams()` serializer compatible with pagination helpers.
- **Issue #76** — Adds `RedactionEngine` with `redactObject()` (shallow), `redactDeep()` (recursive), and `redactError()` for scrubbing sensitive values from logs, errors, and telemetry; `SdkLogger.redactSensitive` now delegates here to keep the field list in one place.

## Test plan

- [ ] `simulatePayroll` returns `canProceed: false` with typed findings for invalid params
- [ ] `simulatePayroll` returns `status: "warning"` for edge-case amounts/assets and `estimatedFee` when valid
- [ ] `exportDraft` → `importDraft` round-trip preserves all fields and passes checksum verification
- [ ] `importDraft` throws on empty/malformed JSON and on checksum mismatch
- [ ] `HistoryFilterBuilder` chains compose correctly and `toParams()` serializes expected keys
- [ ] `PayrollHistoryFilters` shorthand factories produce equivalent single-dimension queries
- [ ] `redactObject` replaces all default sensitive field values, leaves non-sensitive fields intact
- [ ] `redactDeep` recurses into nested objects and arrays
- [ ] `redactError` sanitizes inline field=value patterns in error messages

closes #73      closes #74     closes #75         closes #76