### PR TITLE
feat(errors): add toUserFriendlyError helper for mapping chain errors to userfriendly messages

### DIFF
--- a/docs/API.md
+++ b/docs/API.md
@@ -552,7 +552,7 @@ const proof = await ZKProofGenerator.generateSnarkjsProof(witness, config);
 
 ## Error Handling
 
-All errors are wrapped in `PayrollError`:
+All errors are wrapped in `ZkPayrollError` subclasses:
 
 ```typescript
 import { PayrollError } from "@zk-payroll/sdk";
@@ -565,6 +565,48 @@ try {
   }
 }
 ```
+
+### User-Friendly Error Messages
+
+Use `toUserFriendlyError` to translate raw chain, contract, or SDK errors into clear, human-readable messages while preserving the original diagnostic context:
+
+```typescript
+import { toUserFriendlyError, ContractExecutionError } from "@zk-payroll/sdk";
+
+try {
+  await contract.someMethod();
+} catch (err) {
+  const result = toUserFriendlyError(err);
+
+  // Show to the user
+  console.log(result.friendlyMessage); // "The transaction could not be simulated..."
+
+  // Log for debugging
+  console.error(result.code, result.context);
+}
+```
+
+The return type `UserFriendlyError` provides:
+
+| Field            | Description                                  |
+|------------------|----------------------------------------------|
+| `friendlyMessage`| Human-readable description of the failure    |
+| `code`           | Original error code (`SIMULATION_FAILED`, …) |
+| `context`        | Structured metadata (`transactionId`, …)     |
+| `originalError`  | The raw error for full diagnostics           |
+
+#### Customising Messages
+
+Pass an overrides map to replace default messages for specific error codes:
+
+```typescript
+const result = toUserFriendlyError(err, {
+  SIMULATION_FAILED: "We couldn't verify your transaction. Please try again.",
+  WALLET_SIGNING_REJECTED: "Please approve the signature in your wallet.",
+});
+```
+
+The available error codes are defined in `ContractErrorCode` and `DEFAULT_ERROR_MESSAGES`.
 
 ## See Also
 

--- a/packages/core/src/core/errors.ts
+++ b/packages/core/src/core/errors.ts
@@ -69,6 +69,128 @@ export class ValidationError extends ZkPayrollError {
   }
 }
 
+/**
+ * Default user-friendly messages mapped by error code.
+ * Keys correspond to the `code` property on SDK error classes.
+ */
+export const DEFAULT_ERROR_MESSAGES: Record<string, string> = {
+  [ContractErrorCode.SIMULATION_FAILED]:
+    "The transaction could not be simulated. Please verify your inputs and network connection and try again.",
+  [ContractErrorCode.TRANSACTION_SUBMISSION_FAILED]:
+    "The transaction was rejected by the network. Please check your connection and try again.",
+  [ContractErrorCode.TRANSACTION_TIMEOUT]:
+    "The transaction did not confirm within the expected time. The network may be congested; please retry.",
+  [ContractErrorCode.INSUFFICIENT_FEE]:
+    "The transaction fee was too low. Try increasing the fee and submitting again.",
+  [ContractErrorCode.CONTRACT_REVERT]:
+    "The smart contract rejected the transaction. This may indicate invalid parameters or insufficient permissions.",
+  [ContractErrorCode.UNKNOWN_RPC_ERROR]:
+    "An unexpected error occurred while communicating with the blockchain network. Please try again.",
+  NETWORK_ERROR: "A network error occurred. Please check your internet connection and try again.",
+  PROOF_GENERATION_FAILED:
+    "Zero-knowledge proof generation failed. This may be due to invalid inputs or insufficient system resources.",
+  VALIDATION_ERROR:
+    "The provided parameters failed validation. Please review your inputs and try again.",
+  WALLET_NOT_INSTALLED: "The wallet extension is not installed. Please install it and try again.",
+  WALLET_NOT_CONNECTED: "The wallet is not connected. Please connect your wallet and try again.",
+  WALLET_CONNECTION_REJECTED:
+    "The wallet connection request was rejected. Please approve the connection and try again.",
+  WALLET_SIGNING_REJECTED:
+    "The transaction signing request was rejected. Please approve the signature and try again.",
+  WALLET_NETWORK_MISMATCH:
+    "The wallet is on the wrong network. Please switch to the correct network and try again.",
+  WALLET_INVALID_XDR: "The transaction data is invalid. This may indicate a software bug.",
+  WALLET_UNKNOWN_ERROR: "An unexpected wallet error occurred. Please try again.",
+};
+
+/** Custom message overrides keyed by error code. */
+export type ErrorMessageOverrides = Record<string, string>;
+
+/**
+ * Result of {@link toUserFriendlyError}.
+ *
+ * Contains both a human-readable message and the original diagnostic context
+ * so callers can log the full technical details while displaying the friendly
+ * version to end users.
+ */
+export interface UserFriendlyError {
+  /** Human-readable description of the failure. */
+  friendlyMessage: string;
+  /** Error code from the original error (e.g. `"SIMULATION_FAILED"`). */
+  code: string;
+  /** Structured metadata from the original error. */
+  context: ErrorContext;
+  /** The original error object, preserved for lower-level diagnostics. */
+  originalError: unknown;
+}
+
+function extractCodeAndContext(error: unknown): { code: string; context: ErrorContext } {
+  if (typeof error === "object" && error !== null && "code" in error && "context" in error) {
+    const err = error as { code: unknown; context: unknown };
+    return {
+      code: String(err.code ?? ContractErrorCode.UNKNOWN_RPC_ERROR),
+      context: (typeof err.context === "object" && err.context !== null
+        ? err.context
+        : {}) as ErrorContext,
+    };
+  }
+
+  if (typeof error === "object" && error !== null && "code" in error && "walletId" in error) {
+    const err = error as { code: unknown; walletId: unknown };
+    return {
+      code: String(err.code),
+      context: { walletId: String(err.walletId) } as ErrorContext,
+    };
+  }
+
+  return { code: ContractErrorCode.UNKNOWN_RPC_ERROR, context: {} };
+}
+
+/**
+ * Translates a raw chain, contract, or SDK error into a user-friendly message
+ * while preserving the original diagnostic context.
+ *
+ * @param error  - The error to map (typed SDK error, `WalletError`, `Error`, or raw value).
+ * @param overrides - Optional map of error codes to custom messages.
+ *
+ * @returns A {@link UserFriendlyError} with both a human-readable message and
+ *          the original technical details.
+ *
+ * @example
+ * ```ts
+ * import { toUserFriendlyError, ContractExecutionError, ContractErrorCode } from "@zk-payroll/core";
+ *
+ * try {
+ *   await contract.someMethod();
+ * } catch (err) {
+ *   const result = toUserFriendlyError(err);
+ *   console.log(result.friendlyMessage); // "The transaction could not be simulated..."
+ *   console.log(result.code);            // "SIMULATION_FAILED"
+ *   console.log(result.context);         // { transactionId, contractId, ... }
+ * }
+ * ```
+ *
+ * **Customising messages:**
+ * ```ts
+ * const result = toUserFriendlyError(err, {
+ *   SIMULATION_FAILED: "Custom simulation message",
+ * });
+ * ```
+ */
+export function toUserFriendlyError(
+  error: unknown,
+  overrides?: ErrorMessageOverrides
+): UserFriendlyError {
+  const { code, context } = extractCodeAndContext(error);
+  const messages = { ...DEFAULT_ERROR_MESSAGES, ...overrides };
+  const friendlyMessage =
+    messages[code] ??
+    messages[ContractErrorCode.UNKNOWN_RPC_ERROR] ??
+    "An unexpected error occurred. Please try again.";
+
+  return { friendlyMessage, code, context, originalError: error };
+}
+
 export function mapRpcError(error: unknown, context: ErrorContext = {}): ContractExecutionError {
   if (error instanceof ContractExecutionError) {
     return error;

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -129,3 +129,7 @@ export function handleApiError(error: unknown): void {
   // eslint-disable-next-line no-console
   console.error("API Error:", error);
 }
+
+// ── User-friendly error mapping ─────────────────────────────────────────────
+export { DEFAULT_ERROR_MESSAGES, toUserFriendlyError } from "./core/errors";
+export type { ErrorMessageOverrides, UserFriendlyError } from "./core/errors";

--- a/packages/core/tests/core-errors.test.ts
+++ b/packages/core/tests/core-errors.test.ts
@@ -6,6 +6,7 @@ import {
   ValidationError,
   ContractErrorCode,
   mapRpcError,
+  toUserFriendlyError,
 } from "../src/errors";
 import { PayrollError } from "../src/errors";
 
@@ -171,6 +172,148 @@ describe("Core Error Classes", () => {
     it("keeps name as PayrollError", () => {
       const error = new PayrollError("test", 500);
       expect(error.name).toBe("PayrollError");
+    });
+  });
+
+  describe("toUserFriendlyError", () => {
+    it("maps SIMULATION_FAILED to a simulation-friendly message", () => {
+      const err = new ContractExecutionError(
+        "simulate failed",
+        ContractErrorCode.SIMULATION_FAILED,
+        { transactionId: "tx_sim" }
+      );
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/simulat/i);
+      expect(result.code).toBe(ContractErrorCode.SIMULATION_FAILED);
+    });
+
+    it("maps TRANSACTION_SUBMISSION_FAILED to a submission-friendly message", () => {
+      const err = new ContractExecutionError(
+        "submit failed",
+        ContractErrorCode.TRANSACTION_SUBMISSION_FAILED
+      );
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/rejected|submission|network/i);
+      expect(result.code).toBe(ContractErrorCode.TRANSACTION_SUBMISSION_FAILED);
+    });
+
+    it("maps TRANSACTION_TIMEOUT to a timeout-friendly message", () => {
+      const err = new ContractExecutionError("timed out", ContractErrorCode.TRANSACTION_TIMEOUT);
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/time|congested/i);
+      expect(result.code).toBe(ContractErrorCode.TRANSACTION_TIMEOUT);
+    });
+
+    it("maps INSUFFICIENT_FEE to a fee-friendly message", () => {
+      const err = new ContractExecutionError("fee too low", ContractErrorCode.INSUFFICIENT_FEE);
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/fee/i);
+      expect(result.code).toBe(ContractErrorCode.INSUFFICIENT_FEE);
+    });
+
+    it("maps CONTRACT_REVERT to a revert-friendly message", () => {
+      const err = new ContractExecutionError(
+        "contract reverted",
+        ContractErrorCode.CONTRACT_REVERT
+      );
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/reject|contract/i);
+      expect(result.code).toBe(ContractErrorCode.CONTRACT_REVERT);
+    });
+
+    it("maps UNKNOWN_RPC_ERROR to a generic message", () => {
+      const err = new ContractExecutionError("weird error");
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/unexpected|error/i);
+      expect(result.code).toBe("UNKNOWN_RPC_ERROR");
+    });
+
+    it("maps NetworkError to a network-friendly message", () => {
+      const err = new NetworkError("connection refused");
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/network/i);
+      expect(result.code).toBe("NETWORK_ERROR");
+    });
+
+    it("maps ProofGenerationError to a proof-friendly message", () => {
+      const err = new ProofGenerationError("circuit crashed");
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/proof/i);
+      expect(result.code).toBe("PROOF_GENERATION_FAILED");
+    });
+
+    it("maps ValidationError to a validation-friendly message", () => {
+      const err = new ValidationError("bad input", "amount");
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/validat/i);
+      expect(result.code).toBe("VALIDATION_ERROR");
+    });
+
+    it("maps WalletError-like objects via duck-typing", () => {
+      const walletErr = {
+        name: "WalletError",
+        message: "User rejected signing",
+        code: "WALLET_SIGNING_REJECTED",
+        walletId: "freighter",
+      };
+      const result = toUserFriendlyError(walletErr);
+      expect(result.friendlyMessage).toMatch(/signing|rejected/i);
+      expect(result.code).toBe("WALLET_SIGNING_REJECTED");
+      expect(result.context.walletId).toBe("freighter");
+    });
+
+    it("maps a plain Error with UNKNOWN_RPC_ERROR code", () => {
+      const result = toUserFriendlyError(new Error("something broke"));
+      expect(result.friendlyMessage).toMatch(/unexpected|error/i);
+      expect(result.code).toBe("UNKNOWN_RPC_ERROR");
+      expect(result.context).toEqual({});
+    });
+
+    it("maps a string value gracefully", () => {
+      const result = toUserFriendlyError("raw string error");
+      expect(result.friendlyMessage).toMatch(/unexpected|error/i);
+      expect(result.code).toBe("UNKNOWN_RPC_ERROR");
+    });
+
+    it("preserves original error in result", () => {
+      const original = new ContractExecutionError("test");
+      const result = toUserFriendlyError(original);
+      expect(result.originalError).toBe(original);
+    });
+
+    it("preserves context metadata", () => {
+      const ctx = { transactionId: "tx_abc", contractId: "C_123", network: "testnet" };
+      const err = new ContractExecutionError("fail", ContractErrorCode.SIMULATION_FAILED, ctx);
+      const result = toUserFriendlyError(err);
+      expect(result.context).toEqual(ctx);
+    });
+
+    it("accepts custom message overrides", () => {
+      const err = new ContractExecutionError("sim fail", ContractErrorCode.SIMULATION_FAILED);
+      const overrides = {
+        SIMULATION_FAILED: "Custom simulation message for the user.",
+      };
+      const result = toUserFriendlyError(err, overrides);
+      expect(result.friendlyMessage).toBe(overrides.SIMULATION_FAILED);
+    });
+
+    it("uses default message for unrecognized codes when no override", () => {
+      const err = { code: "SOME_WEIRD_CODE", context: {}, message: "weird" };
+      const result = toUserFriendlyError(err);
+      expect(result.friendlyMessage).toMatch(/unexpected|error/i);
+    });
+
+    it("uses override for unrecognized codes when provided", () => {
+      const err = { code: "SOME_WEIRD_CODE", context: {}, message: "weird" };
+      const overrides = { SOME_WEIRD_CODE: "Handled with custom message." };
+      const result = toUserFriendlyError(err, overrides);
+      expect(result.friendlyMessage).toBe(overrides.SOME_WEIRD_CODE);
+    });
+
+    it("falls back to hardcoded message when even the default map is missing", () => {
+      const unknown = { code: "NO_SUCH_CODE", context: {} };
+      const result = toUserFriendlyError(unknown);
+      expect(result.friendlyMessage).toBeTruthy();
     });
   });
 });


### PR DESCRIPTION
closes #103 