### PR TITLE
 Add structured progress callbacks for long-running payroll preparation steps

### DIFF
--- a/docs/PROGRESS_EVENTS.md
+++ b/docs/PROGRESS_EVENTS.md
@@ -1,0 +1,53 @@
+# Structured Progress Events
+
+Long-running SDK operations can report standardized progress through an `onProgress` callback. The callback receives a typed `PayrollProgressEvent` object instead of positional status arguments.
+
+```ts
+import { PayrollService, PayrollProgressEvent } from "@zk-payroll/core";
+
+const onProgress = (event: PayrollProgressEvent) => {
+  console.log(event.timestamp, event.operation, event.stage, event.progress);
+};
+
+await payroll.processPayment({
+  recipient: "G...",
+  amount: 1_000_000n,
+  asset: "native",
+  onProgress,
+});
+```
+
+## Event shape
+
+```ts
+interface PayrollProgressEvent {
+  operation: "proof" | "payment";
+  stage:
+    | "validation"
+    | "proof_loading_wasm"
+    | "proof_loading_zkey"
+    | "proof_generating"
+    | "proof_done"
+    | "submission_preparing"
+    | "submission_submitting"
+    | "submission_done";
+  message: string;
+  progress?: number;
+  timestamp: string;
+  metadata?: Record<string, unknown>;
+}
+```
+
+## Representative sequence
+
+A payment that needs to load proof artifacts generally emits:
+
+1. `payment.validation`
+2. `proof.proof_loading_wasm`
+3. `proof.proof_loading_zkey`
+4. `proof.proof_generating`
+5. `proof.proof_done`
+6. `payment.submission_preparing`
+7. `payment.submission_done`
+
+Consumers should treat `stage` as the stable UI key. `message` is a machine-readable status detail, `progress` is present only when the SDK can estimate completion, and `metadata` never includes sensitive witness fields such as recipient or amount.

--- a/packages/core/src/crypto/IProofGenerator.ts
+++ b/packages/core/src/crypto/IProofGenerator.ts
@@ -1,5 +1,10 @@
+import type { PayrollProgressCallback } from "../progress";
+
 export interface IProofGenerator {
-  generateProof(witness: Record<string, unknown>): Promise<ProofPayload>;
+  generateProof(
+    witness: Record<string, unknown>,
+    onProgress?: PayrollProgressCallback
+  ): Promise<ProofPayload>;
 }
 
 /** Status returned by preload() and getPreloadStatus(). */

--- a/packages/core/src/crypto/SnarkjsProofGenerator.ts
+++ b/packages/core/src/crypto/SnarkjsProofGenerator.ts
@@ -8,6 +8,8 @@ import {
   PreloadStatus,
 } from "./IProofGenerator";
 import { SdkLogger } from "../logging/SdkLogger";
+import { createPayrollProgressEvent } from "../progress";
+import type { PayrollProgressCallback } from "../progress";
 import { IArtifactResolver, ArtifactSource } from "./IArtifactResolver";
 import { LocalArtifactResolver } from "./LocalArtifactResolver";
 import { RemoteArtifactResolver } from "./RemoteArtifactResolver";
@@ -209,7 +211,10 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
     this.resolver = buildResolver(config, logger);
   }
 
-  async generateProof(witness: Record<string, unknown>): Promise<ProofPayload> {
+  async generateProof(
+    witness: Record<string, unknown>,
+    onProgress?: PayrollProgressCallback
+  ): Promise<ProofPayload> {
     this.logger?.info("proof_generation_start", { wasmUrl: this.config.wasmUrl });
 
     try {
@@ -218,13 +223,43 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
         const cached = await this.cache.get(cacheKey);
         if (cached !== null) {
           this.logger?.info("proof_cache_hit");
+          onProgress?.(
+            createPayrollProgressEvent({
+              operation: "proof",
+              stage: "proof_done",
+              message: "proof_cache_hit",
+              progress: 100,
+            })
+          );
           return JSON.parse(cached);
         }
         this.logger?.info("proof_cache_miss");
       }
 
+      onProgress?.(
+        createPayrollProgressEvent({
+          operation: "proof",
+          stage: "proof_loading_wasm",
+          message: "loading_wasm",
+        })
+      );
+      onProgress?.(
+        createPayrollProgressEvent({
+          operation: "proof",
+          stage: "proof_loading_zkey",
+          message: "loading_zkey",
+        })
+      );
       const [wasm, zkey] = await Promise.all([this.fetchWasm(), this.fetchZkey()]);
 
+      onProgress?.(
+        createPayrollProgressEvent({
+          operation: "proof",
+          stage: "proof_generating",
+          message: "generating",
+          progress: 0,
+        })
+      );
       const { proof, publicSignals } = await groth16.fullProve(witness, wasm, zkey);
 
       const payload = this.formatProofPayload(proof, publicSignals);
@@ -236,6 +271,14 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
       }
 
       this.logger?.info("proof_generation_complete");
+      onProgress?.(
+        createPayrollProgressEvent({
+          operation: "proof",
+          stage: "proof_done",
+          message: "done",
+          progress: 100,
+        })
+      );
       return payload;
     } catch (error) {
       this.logger?.error("proof_generation_failed", {

--- a/packages/core/src/crypto/WorkerMessages.ts
+++ b/packages/core/src/crypto/WorkerMessages.ts
@@ -1,4 +1,5 @@
 import type { ProofPayload, ProofGeneratorConfig } from "./IProofGenerator";
+import type { PayrollProgressEvent } from "../progress";
 
 /**
  * Stages emitted as proof generation progresses inside the worker.
@@ -31,6 +32,6 @@ export type WorkerRequest =
 export type WorkerResponse =
   | { type: "PROOF_RESULT"; id: string; payload: ProofPayload }
   | { type: "PROOF_ERROR"; id: string; message: string }
-  | { type: "PROGRESS"; id: string; stage: ProofProgressStage; progress?: number }
+  | { type: "PROGRESS"; id: string; event: PayrollProgressEvent }
   | { type: "PRELOAD_DONE"; id: string }
   | { type: "CACHE_CLEARED"; id: string };

--- a/packages/core/src/crypto/WorkerProofGenerator.ts
+++ b/packages/core/src/crypto/WorkerProofGenerator.ts
@@ -1,14 +1,7 @@
 import { IProofGenerator, ProofPayload, ProofGeneratorConfig } from "./IProofGenerator";
-import { WorkerRequest, WorkerResponse, ProofProgressStage } from "./WorkerMessages";
+import { WorkerRequest, WorkerResponse } from "./WorkerMessages";
 import { PayrollError } from "../errors";
-
-/**
- * Callback invoked as the worker reports proof generation progress.
- *
- * @param stage    - Current stage of work inside the worker
- * @param progress - Optional 0-100 completion percentage
- */
-export type ProofProgressCallback = (stage: ProofProgressStage, progress?: number) => void;
+import type { PayrollProgressCallback } from "../progress";
 
 /**
  * Options for WorkerProofGenerator.
@@ -18,7 +11,7 @@ export interface WorkerProofOptions {
    * Global progress handler applied to every generateProof call unless
    * overridden by the per-call onProgress argument.
    */
-  onProgress?: ProofProgressCallback;
+  onProgress?: PayrollProgressCallback;
   /**
    * Maximum milliseconds to wait for the worker to respond before
    * rejecting with a timeout error. Defaults to 120 000 ms (2 minutes).
@@ -33,26 +26,17 @@ export interface WorkerProofOptions {
  */
 export interface WorkerLike {
   postMessage(message: WorkerRequest): void;
-  addEventListener(
-    type: "message",
-    listener: (event: { data: WorkerResponse }) => void
-  ): void;
+  addEventListener(type: "message", listener: (event: { data: WorkerResponse }) => void): void;
   addEventListener(type: "error", listener: (event: { message: string }) => void): void;
-  removeEventListener(
-    type: "message",
-    listener: (event: { data: WorkerResponse }) => void
-  ): void;
-  removeEventListener(
-    type: "error",
-    listener: (event: { message: string }) => void
-  ): void;
+  removeEventListener(type: "message", listener: (event: { data: WorkerResponse }) => void): void;
+  removeEventListener(type: "error", listener: (event: { message: string }) => void): void;
   terminate(): void;
 }
 
 interface PendingRequest {
   resolve: (payload: ProofPayload) => void;
   reject: (err: Error) => void;
-  onProgress?: ProofProgressCallback;
+  onProgress?: PayrollProgressCallback;
   timer: ReturnType<typeof setTimeout>;
 }
 
@@ -119,13 +103,11 @@ export class WorkerProofGenerator implements IProofGenerator {
       case "PROOF_ERROR":
         clearTimeout(pending.timer);
         this.pending.delete(msg.id);
-        pending.reject(
-          new PayrollError(`Worker proof generation failed: ${msg.message}`, 500)
-        );
+        pending.reject(new PayrollError(`Worker proof generation failed: ${msg.message}`, 500));
         break;
 
       case "PROGRESS":
-        pending.onProgress?.(msg.stage, msg.progress);
+        pending.onProgress?.(msg.event);
         break;
 
       case "PRELOAD_DONE":
@@ -152,18 +134,13 @@ export class WorkerProofGenerator implements IProofGenerator {
 
   private dispatch(
     req: WorkerRequest,
-    onProgress?: ProofProgressCallback
+    onProgress?: PayrollProgressCallback
   ): Promise<ProofPayload> {
     return new Promise<ProofPayload>((resolve, reject) => {
       const timeoutMs = this.options.timeoutMs ?? 120_000;
       const timer = setTimeout(() => {
         this.pending.delete(req.id);
-        reject(
-          new PayrollError(
-            `Proof generation timed out after ${timeoutMs}ms`,
-            408
-          )
-        );
+        reject(new PayrollError(`Proof generation timed out after ${timeoutMs}ms`, 408));
       }, timeoutMs);
 
       this.pending.set(req.id, {
@@ -192,7 +169,7 @@ export class WorkerProofGenerator implements IProofGenerator {
    */
   generateProof(
     witness: Record<string, unknown>,
-    onProgress?: ProofProgressCallback
+    onProgress?: PayrollProgressCallback
   ): Promise<ProofPayload> {
     return this.dispatch(
       { type: "GENERATE_PROOF", id: this.nextId(), witness, config: this.config },
@@ -217,9 +194,7 @@ export class WorkerProofGenerator implements IProofGenerator {
    * on the next proof generation request.
    */
   clearCache(): Promise<void> {
-    return this.dispatch({ type: "CLEAR_CACHE", id: this.nextId() }).then(
-      () => undefined
-    );
+    return this.dispatch({ type: "CLEAR_CACHE", id: this.nextId() }).then(() => undefined);
   }
 
   /**

--- a/packages/core/src/crypto/proof.worker.ts
+++ b/packages/core/src/crypto/proof.worker.ts
@@ -16,6 +16,8 @@
 import { groth16 } from "snarkjs";
 import type { ProofPayload, ProofGeneratorConfig } from "./IProofGenerator";
 import type { WorkerRequest, WorkerResponse, ProofProgressStage } from "./WorkerMessages";
+import { createPayrollProgressEvent } from "../progress";
+import type { PayrollProgressStage } from "../progress";
 
 // Typed reference to the Web Worker global scope.
 // Using an interface avoids conflicts between the DOM lib (Window) and the
@@ -39,8 +41,24 @@ function emit(msg: WorkerResponse): void {
   scope.postMessage(msg);
 }
 
+const workerStageMap: Record<ProofProgressStage, PayrollProgressStage> = {
+  loading_wasm: "proof_loading_wasm",
+  loading_zkey: "proof_loading_zkey",
+  generating: "proof_generating",
+  done: "proof_done",
+};
+
 function emitProgress(id: string, stage: ProofProgressStage, progress?: number): void {
-  emit({ type: "PROGRESS", id, stage, progress });
+  emit({
+    type: "PROGRESS",
+    id,
+    event: createPayrollProgressEvent({
+      operation: "proof",
+      stage: workerStageMap[stage],
+      message: stage,
+      progress,
+    }),
+  });
 }
 
 async function loadWasm(url: string, id: string): Promise<ArrayBuffer> {

--- a/packages/core/src/errors.ts
+++ b/packages/core/src/errors.ts
@@ -30,9 +30,8 @@ export class PayrollError extends ZkPayrollError {
   constructor(message: string, code: number) {
     super(message, String(code));
     this.name = "PayrollError";
+    (this as unknown as { code: number }).code = code;
   }
-
-  return new ContractExecutionError(message, code, context);
 }
 
 /** @deprecated Use structured error logging instead. */

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -14,11 +14,7 @@ export { PayrollContract } from "./contract";
 export { ZKProofGenerator } from "./crypto/proofs";
 export { SnarkjsProofGenerator } from "./crypto/SnarkjsProofGenerator";
 export { WorkerProofGenerator } from "./crypto/WorkerProofGenerator";
-export type {
-  WorkerLike,
-  WorkerProofOptions,
-  ProofProgressCallback,
-} from "./crypto/WorkerProofGenerator";
+export type { WorkerLike, WorkerProofOptions } from "./crypto/WorkerProofGenerator";
 export type { WorkerRequest, WorkerResponse, ProofProgressStage } from "./crypto/WorkerMessages";
 export {
   ZkPayrollError,
@@ -34,6 +30,7 @@ export type { ErrorContext, ContractErrorCodeType } from "./errors";
 export { DEFAULT_CONFIG } from "./config";
 export * from "./cache";
 export * from "./types";
+export * from "./progress";
 export { IdempotencyRegistry, createPaymentIdempotencyKey } from "./core/idempotency";
 export * from "./crypto/IProofGenerator";
 export * from "./adapters";

--- a/packages/core/src/payroll.ts
+++ b/packages/core/src/payroll.ts
@@ -7,6 +7,7 @@ import { PayrollError, PayrollServiceErrorCode } from "./errors";
 import { PaymentParams, PaymentResult } from "./types";
 import { SdkLogger } from "./logging/SdkLogger";
 import { IdempotencyRegistry, createPaymentIdempotencyKey } from "./core/idempotency";
+import { createPayrollProgressEvent } from "./progress";
 
 export interface Transaction {
   amount: bigint;
@@ -58,7 +59,9 @@ export class PayrollService {
   /**
    * Build a deterministic idempotency key from payment data.
    */
-  static createIdempotencyKey(params: Pick<PaymentParams, "recipient" | "amount" | "asset">): string {
+  static createIdempotencyKey(
+    params: Pick<PaymentParams, "recipient" | "amount" | "asset">
+  ): string {
     return createPaymentIdempotencyKey(params);
   }
 
@@ -68,8 +71,24 @@ export class PayrollService {
     this.logger?.info("payment_start");
 
     // 1. Validate inputs
+    params.onProgress?.(
+      createPayrollProgressEvent({
+        operation: "payment",
+        stage: "validation",
+        message: "validation_started",
+        progress: 0,
+      })
+    );
     try {
       this.validatePaymentParams(params);
+      params.onProgress?.(
+        createPayrollProgressEvent({
+          operation: "payment",
+          stage: "validation",
+          message: "validation_completed",
+          progress: 100,
+        })
+      );
     } catch (error) {
       this.logger?.warn("payment_validation_failed", {
         error: error instanceof Error ? error.message : String(error),
@@ -86,7 +105,7 @@ export class PayrollService {
 
     let proof: ProofPayload;
     try {
-      proof = await this.proofGenerator.generateProof(witness);
+      proof = await this.proofGenerator.generateProof(witness, params.onProgress);
     } catch (error) {
       if (error instanceof PayrollError) {
         throw error;
@@ -98,6 +117,15 @@ export class PayrollService {
     }
 
     // 3. Invoke contract
+    params.onProgress?.(
+      createPayrollProgressEvent({
+        operation: "payment",
+        stage: "submission_preparing",
+        message: "submission_preparing",
+        progress: 0,
+        metadata: { method: "private_pay" },
+      })
+    );
     this.logger?.info("contract_invocation_start", { method: "private_pay" });
 
     const resultXdr = await this.contractWrapper.privatePay(
@@ -108,6 +136,16 @@ export class PayrollService {
       this.signer,
       this.network,
       params.idempotencyKey ? { idempotencyKey: params.idempotencyKey } : undefined
+    );
+
+    params.onProgress?.(
+      createPayrollProgressEvent({
+        operation: "payment",
+        stage: "submission_done",
+        message: "submission_done",
+        progress: 100,
+        metadata: { method: "private_pay" },
+      })
     );
 
     const result: PaymentResult = {

--- a/packages/core/src/progress.ts
+++ b/packages/core/src/progress.ts
@@ -1,0 +1,39 @@
+/** High-level SDK operations that can report structured progress. */
+export type PayrollProgressOperation = "proof" | "payment";
+
+/** Standardized stages emitted by long-running SDK operations. */
+export type PayrollProgressStage =
+  | "validation"
+  | "proof_loading_wasm"
+  | "proof_loading_zkey"
+  | "proof_generating"
+  | "proof_done"
+  | "submission_preparing"
+  | "submission_submitting"
+  | "submission_done";
+
+/** Structured progress event emitted by payroll preparation flows. */
+export interface PayrollProgressEvent {
+  /** Operation that emitted the event. */
+  operation: PayrollProgressOperation;
+  /** Current SDK stage. */
+  stage: PayrollProgressStage;
+  /** Stable machine-readable message for UI mapping and logs. */
+  message: string;
+  /** Optional completion percentage from 0 to 100 when known. */
+  progress?: number;
+  /** ISO timestamp for ordering events across async boundaries. */
+  timestamp: string;
+  /** Additional non-sensitive metadata about the event. */
+  metadata?: Record<string, unknown>;
+}
+
+/** Callback used by SDK APIs that support structured progress reporting. */
+export type PayrollProgressCallback = (event: PayrollProgressEvent) => void;
+
+/** Build a timestamped progress event with a consistent shape. */
+export function createPayrollProgressEvent(
+  event: Omit<PayrollProgressEvent, "timestamp">
+): PayrollProgressEvent {
+  return { ...event, timestamp: new Date().toISOString() };
+}

--- a/packages/core/src/types/index.ts
+++ b/packages/core/src/types/index.ts
@@ -1,3 +1,5 @@
+import type { PayrollProgressCallback } from "../progress";
+
 export interface PayrollRecord {
   id: string;
   recipient: string;
@@ -22,6 +24,8 @@ export interface PaymentParams {
    * without triggering duplicate submissions.
    */
   idempotencyKey?: string;
+  /** Optional structured progress handler for validation, proof, and submission preparation. */
+  onProgress?: PayrollProgressCallback;
 }
 
 /**

--- a/packages/core/tests/payroll-service.test.ts
+++ b/packages/core/tests/payroll-service.test.ts
@@ -44,11 +44,14 @@ describe("PayrollService", () => {
         asset: "native",
       });
 
-      expect(mockProofGen.generateProof).toHaveBeenCalledWith({
-        recipient: "GABC123",
-        amount: "1000000",
-        asset: "native",
-      });
+      expect(mockProofGen.generateProof).toHaveBeenCalledWith(
+        {
+          recipient: "GABC123",
+          amount: "1000000",
+          asset: "native",
+        },
+        undefined
+      );
     });
 
     it("invokes contract.privatePay with correct args after proof generation", async () => {
@@ -71,6 +74,44 @@ describe("PayrollService", () => {
       expect(typeof callArgs[4].getPublicKey).toBe("function");
       expect(typeof callArgs[4].sign).toBe("function");
       expect(callArgs[5]).toBe(Networks.TESTNET);
+    });
+
+    it("emits structured progress for validation, proof generation, and submission prep", async () => {
+      const { mockWrapper, mockProofGen, signer } = createMocks();
+      const service = new PayrollService(mockWrapper, mockProofGen, signer);
+      const onProgress = jest.fn();
+
+      (mockProofGen.generateProof as jest.Mock).mockImplementation(async (_witness, progress) => {
+        progress({
+          operation: "proof",
+          stage: "proof_generating",
+          message: "generating",
+          progress: 0,
+          timestamp: "2026-06-30T00:00:00.000Z",
+        });
+        return MOCK_PROOF;
+      });
+
+      await service.processPayment({
+        recipient: "GABC123",
+        amount: 100n,
+        asset: "native",
+        onProgress,
+      });
+
+      expect(mockProofGen.generateProof).toHaveBeenCalledWith(expect.any(Object), onProgress);
+      expect(onProgress.mock.calls.map(([event]) => event.stage)).toEqual([
+        "validation",
+        "validation",
+        "proof_generating",
+        "submission_preparing",
+        "submission_done",
+      ]);
+      expect(onProgress.mock.calls[0][0]).toMatchObject({
+        operation: "payment",
+        message: "validation_started",
+        progress: 0,
+      });
     });
 
     it("returns a PaymentResult with txHash and publicSignals", async () => {
@@ -106,7 +147,7 @@ describe("PayrollService", () => {
 
       expect(first).toEqual(second);
       expect(mockProofGen.generateProof).toHaveBeenCalledTimes(1);
-      expect((mockWrapper.privatePay as jest.Mock)).toHaveBeenCalledTimes(1);
+      expect(mockWrapper.privatePay as jest.Mock).toHaveBeenCalledTimes(1);
     });
 
     it("does not deduplicate when idempotencyKey is omitted", async () => {
@@ -117,7 +158,7 @@ describe("PayrollService", () => {
       await service.processPayment({ recipient: "GABC123", amount: 100n, asset: "native" });
 
       expect(mockProofGen.generateProof).toHaveBeenCalledTimes(2);
-      expect((mockWrapper.privatePay as jest.Mock)).toHaveBeenCalledTimes(2);
+      expect(mockWrapper.privatePay as jest.Mock).toHaveBeenCalledTimes(2);
     });
 
     it("builds deterministic idempotency keys for payment payloads", () => {

--- a/packages/core/tests/worker-proof-generator.test.ts
+++ b/packages/core/tests/worker-proof-generator.test.ts
@@ -2,6 +2,7 @@ import { WorkerProofGenerator, WorkerLike } from "../src/crypto/WorkerProofGener
 import { ProofGeneratorConfig, ProofPayload } from "../src/crypto/IProofGenerator";
 import { WorkerResponse, WorkerRequest } from "../src/crypto/WorkerMessages";
 import { PayrollError } from "../src/errors";
+import { createPayrollProgressEvent, PayrollProgressStage } from "../src/progress";
 
 // ── Fake Worker ───────────────────────────────────────────────────────────────
 
@@ -81,6 +82,15 @@ const mockPayload: ProofPayload = {
   publicSignals: ["100", "200"],
 };
 
+function progressEvent(stage: PayrollProgressStage, progress?: number) {
+  return createPayrollProgressEvent({
+    operation: "proof",
+    stage,
+    message: stage,
+    progress,
+  });
+}
+
 function setup(opts?: ConstructorParameters<typeof WorkerProofGenerator>[2]) {
   const worker = new FakeWorker();
   const generator = new WorkerProofGenerator(worker, config, opts);
@@ -138,15 +148,15 @@ describe("WorkerProofGenerator", () => {
       const promise = generator.generateProof({ amount: 100n }, onProgress);
       const { id } = worker.lastRequest();
 
-      worker.reply({ type: "PROGRESS", id, stage: "loading_wasm" });
-      worker.reply({ type: "PROGRESS", id, stage: "generating", progress: 0 });
+      worker.reply({ type: "PROGRESS", id, event: progressEvent("proof_loading_wasm") });
+      worker.reply({ type: "PROGRESS", id, event: progressEvent("proof_generating", 0) });
       worker.reply({ type: "PROOF_RESULT", id, payload: mockPayload });
 
       await promise;
 
       expect(onProgress).toHaveBeenCalledTimes(2);
-      expect(onProgress).toHaveBeenNthCalledWith(1, "loading_wasm", undefined);
-      expect(onProgress).toHaveBeenNthCalledWith(2, "generating", 0);
+      expect(onProgress.mock.calls[0][0]).toMatchObject({ stage: "proof_loading_wasm" });
+      expect(onProgress.mock.calls[1][0]).toMatchObject({ stage: "proof_generating", progress: 0 });
     });
 
     it("falls back to global onProgress when no per-call callback is supplied", async () => {
@@ -156,11 +166,11 @@ describe("WorkerProofGenerator", () => {
       const promise = generator.generateProof({ amount: 200n });
       const { id } = worker.lastRequest();
 
-      worker.reply({ type: "PROGRESS", id, stage: "loading_zkey" });
+      worker.reply({ type: "PROGRESS", id, event: progressEvent("proof_loading_zkey") });
       worker.reply({ type: "PROOF_RESULT", id, payload: mockPayload });
 
       await promise;
-      expect(globalProgress).toHaveBeenCalledWith("loading_zkey", undefined);
+      expect(globalProgress.mock.calls[0][0]).toMatchObject({ stage: "proof_loading_zkey" });
     });
 
     it("per-call onProgress overrides the global one", async () => {
@@ -171,11 +181,14 @@ describe("WorkerProofGenerator", () => {
       const promise = generator.generateProof({ amount: 300n }, perCallProgress);
       const { id } = worker.lastRequest();
 
-      worker.reply({ type: "PROGRESS", id, stage: "generating", progress: 50 });
+      worker.reply({ type: "PROGRESS", id, event: progressEvent("proof_generating", 50) });
       worker.reply({ type: "PROOF_RESULT", id, payload: mockPayload });
 
       await promise;
-      expect(perCallProgress).toHaveBeenCalledWith("generating", 50);
+      expect(perCallProgress.mock.calls[0][0]).toMatchObject({
+        stage: "proof_generating",
+        progress: 50,
+      });
       expect(globalProgress).not.toHaveBeenCalled();
     });
 


### PR DESCRIPTION
### Description
- Add a new `packages/core/src/progress.ts` exporting `PayrollProgressEvent`, `PayrollProgressCallback`, `PayrollProgressStage`, `createPayrollProgressEvent`, and related types. 
- Update the proof-generation surface by changing `IProofGenerator.generateProof` to accept an optional `onProgress?: PayrollProgressCallback`, and wire `SnarkjsProofGenerator` to emit structured events for cache hits, wasm/zkey loading, generating, and completion. 
- Convert worker messaging to carry `PayrollProgressEvent` via `WorkerMessages.ts`, adapt `proof.worker.ts` to build `PayrollProgressEvent` objects, and update `WorkerProofGenerator` to forward events to per-call or global callbacks. 
- Expose `onProgress` on `PaymentParams`, have `PayrollService.processPayment` emit validation and submission-preparation/completion events and forward `onProgress` into `generateProof`, and export the progress API from the package entry point; add `docs/PROGRESS_EVENTS.md` documenting usage. 
- Update tests to assert representative progress sequences and update worker progress tests to use the new structured event payloads, and fix a backward-compatible `PayrollError` numeric `code` preservation to satisfy existing expectations.

closes #72 