### PR TITLE
feat(core): add binary serialization helpers

### DIFF
--- a/docs/BINARY_SERIALIZATION.md
+++ b/docs/BINARY_SERIALIZATION.md
@@ -1,0 +1,284 @@
+# ZK Payroll SDK
+
+TypeScript SDK for interacting with the ZK Payroll smart contracts.
+
+## Installation
+
+```bash
+npm install @zk-payroll/sdk
+```
+
+## Usage
+
+```typescript
+import { PayrollService, DEFAULT_CONFIG } from "@zk-payroll/sdk";
+
+// Initialize service
+const service = new PayrollService(DEFAULT_CONFIG);
+
+// Process a private payment
+await service.processPayment(
+  "G...", // Recipient Stellar address
+  1000n   // Amount
+);
+```
+
+## Idempotent retries
+
+For safe retries, pass an `idempotencyKey` when processing a payment.
+
+```typescript
+import { PayrollService, createPaymentIdempotencyKey } from "@zk-payroll/sdk";
+
+const idempotencyKey = createPaymentIdempotencyKey({
+  recipient: "G...",
+  amount: 1000n,
+  asset: "native",
+});
+
+await service.processPayment({
+  recipient: "G...",
+  amount: 1000n,
+  asset: "native",
+  idempotencyKey,
+});
+```
+
+## Features
+
+- **Typed Contract Clients**: Fully typed client wrappers for PayrollRegistry, SalaryCommitment, ProofVerifier, and PaymentExecutor contracts.
+- **ZK Proof Generation**: Client-side proof generation using snarkjs for privacy.
+- **Caching**: Built-in caching for proofs and circuit artifacts.
+- **Error Handling**: Robust error typing and management.
+- **Mock Testing Environment**: Comprehensive testing utilities for unit tests without a live network.
+
+## Zero-Knowledge Proof Generation
+
+The SDK includes production-ready ZK proof generation using snarkjs:
+
+```typescript
+import { SnarkjsProofGenerator, MemoryCacheProvider } from "@zk-payroll/sdk";
+
+// Configure circuit artifacts
+const config = {
+  wasmUrl: "https://cdn.example.com/payroll_circuit.wasm",
+  zkeyUrl: "https://cdn.example.com/payroll_circuit.zkey",
+  artifactCacheTTL: 86400, // 24 hours
+};
+
+// Create generator with caching
+const cache = new MemoryCacheProvider<string>();
+const generator = new SnarkjsProofGenerator(config, cache);
+
+// Generate proof
+const witness = {
+  recipient: "GDZQHV...",
+  amount: 1000000n,
+  nullifier: 123456789n,
+  secret: 987654321n,
+};
+
+const proof = await generator.generateProof(witness);
+```
+
+See [ZK Proof Generation Guide](./docs/ZK_PROOF_GENERATION.md) for detailed documentation.
+
+## Backend Worker Quickstart
+
+Teams building internal payroll automation workers can follow the [Backend Worker Quickstart](./docs/BACKEND_WORKER_QUICKSTART.md) for a practical end-to-end prototype covering setup, polling, retries, and event handling.
+
+## Testing
+
+The SDK includes a powerful mock testing environment for writing unit tests:
+
+```typescript
+import { MockContractEnvironment, MockPayrollContract } from "@zk-payroll/sdk";
+
+const mockEnv = new MockContractEnvironment();
+mockEnv.expectInvoke("deposit").toReturn("tx_hash_123");
+
+const mockContract = new MockPayrollContract(mockEnv);
+const txHash = await mockContract.deposit(1000n);
+```
+
+See the [Testing Guide](docs/TESTING.md) for complete documentation.
+
+## Typed Contract Clients
+
+The SDK provides typed client wrappers for the core ZK Payroll contracts. Each client exposes typed methods that encode arguments and decode responses automatically.
+
+### PayrollRegistryClient
+
+```typescript
+import { PayrollRegistryClient, rpc } from "@zk-payroll/sdk";
+
+const server = new rpc.Server("https://soroban-testnet.stellar.org");
+const client = new PayrollRegistryClient(server, "CCONTRACT_ID...");
+
+// Register a payroll relationship
+await client.register(
+  { employer: "G...", employee: "G...", salary: 1000n, token: "C...", metadata: "engineering" },
+  signer
+);
+
+// Query a registry entry
+const entry = await client.getRegistry("G...", "G...", signer);
+console.log(entry.salary, entry.active);
+
+// List employees
+const employees = await client.getEmployees("G...", 0, 10, signer);
+
+// Check if a registry exists
+const exists = await client.registryExists("G...", "G...", signer);
+```
+
+### SalaryCommitmentClient
+
+```typescript
+import { SalaryCommitmentClient } from "@zk-payroll/sdk";
+
+const client = new SalaryCommitmentClient(server, "CCONTRACT_ID...");
+
+// Commit to a salary amount (hidden via hash)
+await client.commit(
+  { employer: "G...", employee: "G...", commitmentHash: "abcd...", cycleId: 1n },
+  signer
+);
+
+// Retrieve a commitment
+const commitment = await client.getCommitment("G...", "G...", 1n, signer);
+
+// Batch commit multiple salaries
+await client.batchCommit("G...", [
+  { employee: "G...1", commitmentHash: "abcd", cycleId: 1n },
+  { employee: "G...2", commitmentHash: "ef01", cycleId: 1n },
+], signer);
+
+// Verify a commitment against a ZK proof
+const isValid = await client.verifyCommitment("G...", "G...", 1n, proof, signer);
+
+// Reveal the actual salary
+await client.revealSalary("G...", "G...", 1n, 1000n, signer);
+```
+
+### ProofVerifierClient
+
+```typescript
+import { ProofVerifierClient } from "@zk-payroll/sdk";
+
+const client = new ProofVerifierClient(server, "CCONTRACT_ID...");
+
+// Verify a ZK proof on-chain
+const valid = await client.verify(
+  { pi_a: ["1","2"], pi_b: [["3","4"],["5","6"]], pi_c: ["7","8"], publicSignals: ["sig1"] },
+  ["input1"],
+  1, // verification key ID
+  signer
+);
+
+// Add a new verification key
+const vkId = await client.addVerificationKey("aabbcc...", "groth16 key", signer);
+
+// Get active verification key
+const activeId = await client.getActiveVerificationKeyId(signer);
+
+// Get verification key info
+const info = await client.getVerificationKeyInfo(1, signer);
+```
+
+### PaymentExecutorClient
+
+```typescript
+import { PaymentExecutorClient } from "@zk-payroll/sdk";
+
+const client = new PaymentExecutorClient(server, "CCONTRACT_ID...");
+
+// Execute an immediate payment
+const result = await client.execute(
+  { recipient: "G...", amount: 1000n, asset: "C...", memo: "salary" },
+  signer
+);
+console.log("Transaction:", result.txHash);
+
+// Schedule a future payment
+const scheduled = await client.schedule(
+  { recipient: "G...", amount: 500n, asset: "C...", executeAt: 1700000000, memo: "bonus" },
+  signer
+);
+console.log("Payment ID:", scheduled.paymentId);
+
+// Cancel a scheduled payment
+await client.cancel(scheduled.paymentId, signer);
+
+// Get pending payments
+const payments = await client.getPendingPayments("G...", 0n, 20, signer);
+```
+
+## Environment Sanity Checker
+
+To catch configuration integration problems (such as misconfigured RPC endpoints, invalid contract IDs, or missing/unreachable circuit artifacts) before starting runtime work, the SDK provides the `validateEnvironment` helper:
+
+```typescript
+import { validateEnvironment } from "@zk-payroll/sdk";
+
+const clientConfig = {
+  networkUrl: "https://soroban-testnet.stellar.org",
+  contractId: "CCONTRACT_ID...",
+};
+
+const proofConfig = {
+  wasmUrl: "https://cdn.example.com/payroll_circuit.wasm",
+  zkeyUrl: "https://cdn.example.com/payroll_circuit.zkey",
+};
+
+const result = await validateEnvironment(clientConfig, proofConfig);
+
+if (!result.isValid) {
+  console.error("Environment check failed!");
+  for (const diagnostic of result.diagnostics) {
+    if (diagnostic.status === "error") {
+      console.error(`- [${diagnostic.component}] ${diagnostic.message}`);
+    }
+  }
+} else {
+  console.log("Environment is ready!");
+}
+```
+
+### Diagnostic Result Structure
+
+`validateEnvironment` returns a `SanityCheckResult` containing:
+- `isValid: boolean` - `true` if all validations pass with no errors.
+- `diagnostics: DiagnosticEntry[]` - List of diagnostics for each checked component.
+
+Each `DiagnosticEntry` contains:
+- `component: "rpc" | "contract" | "artifacts"` - The checked component.
+- `status: "success" | "warning" | "error"` - The validation status.
+- `message: string` - Actionable diagnostic message explaining the result.
+- `error?: Error` - The caught error object, if any.
+- `details?: Record<string, unknown>` - Extra context (e.g. network passphrases or RPC response details).
+
+## Documentation
+
+- [API Reference](./docs/API.md) - Complete API documentation
+- [ZK Proof Generation](./docs/ZK_PROOF_GENERATION.md) - Detailed proof generation guide
+- [Binary Serialization](./docs/BINARY_SERIALIZATION.md) - Binary-safe wire format for proof and commitment payloads
+- [Troubleshooting](./docs/TROUBLESHOOTING.md) - Solutions for common CI, dependency, and environment issues
+
+## Development
+
+```bash
+# Install dependencies
+npm install
+
+# Build
+npm run build
+
+# Run tests
+npm test
+
+# Lint
+npm run lint
+```
+
+> Having trouble? See the [Troubleshooting Guide](./docs/TROUBLESHOOTING.md).

--- a/packages/core/src/serialization/BinaryReader.ts
+++ b/packages/core/src/serialization/BinaryReader.ts
@@ -1,0 +1,102 @@
+import { SerializationError } from "./errors";
+
+/**
+ * Reads primitive values sequentially from a byte buffer, mirroring
+ * {@link BinaryWriter}'s little-endian wire format. Every read advances an
+ * internal cursor; out-of-bounds reads throw {@link SerializationError}
+ * instead of returning undefined/garbage, so truncated or corrupt buffers
+ * fail fast and loudly.
+ */
+export class BinaryReader {
+  private offset = 0;
+  private view: DataView;
+  private decoder = new TextDecoder();
+
+  constructor(private readonly bytes: Uint8Array) {
+    this.view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength);
+  }
+
+  /** Number of bytes remaining after the current cursor position. */
+  get remaining(): number {
+    return this.bytes.length - this.offset;
+  }
+
+  private ensure(byteCount: number): void {
+    if (this.remaining < byteCount) {
+      throw new SerializationError(
+        `Unexpected end of buffer: need ${byteCount} byte(s) at offset ${this.offset}, ` +
+          `only ${this.remaining} remaining.`,
+        "SERIALIZATION_TRUNCATED"
+      );
+    }
+  }
+
+  readUint8(): number {
+    this.ensure(1);
+    const value = this.view.getUint8(this.offset);
+    this.offset += 1;
+    return value;
+  }
+
+  readUint32(): number {
+    this.ensure(4);
+    const value = this.view.getUint32(this.offset, true);
+    this.offset += 4;
+    return value;
+  }
+
+  readFloat64(): number {
+    this.ensure(8);
+    const value = this.view.getFloat64(this.offset, true);
+    this.offset += 8;
+    return value;
+  }
+
+  readBool(): boolean {
+    return this.readUint8() !== 0;
+  }
+
+  readBigInt(): bigint {
+    const length = this.readUint32();
+    if (length === 0) {
+      return 0n;
+    }
+    this.ensure(length);
+    let value = 0n;
+    for (let i = 0; i < length; i++) {
+      value = (value << 8n) | BigInt(this.bytes[this.offset + i]);
+    }
+    this.offset += length;
+    return value;
+  }
+
+  readString(): string {
+    const length = this.readUint32();
+    this.ensure(length);
+    const slice = this.bytes.subarray(this.offset, this.offset + length);
+    this.offset += length;
+    return this.decoder.decode(slice);
+  }
+
+  readStringArray(): string[] {
+    const count = this.readUint32();
+    const values: string[] = [];
+    for (let i = 0; i < count; i++) {
+      values.push(this.readString());
+    }
+    return values;
+  }
+
+  /**
+   * Asserts the buffer has been fully consumed. Useful at the end of a
+   * decode to catch payloads with unexpected trailing bytes.
+   */
+  assertExhausted(): void {
+    if (this.remaining !== 0) {
+      throw new SerializationError(
+        `Buffer has ${this.remaining} unexpected trailing byte(s) after decoding.`,
+        "SERIALIZATION_TRAILING_BYTES"
+      );
+    }
+  }
+}

--- a/packages/core/src/serialization/BinaryWriter.ts
+++ b/packages/core/src/serialization/BinaryWriter.ts
@@ -1,0 +1,98 @@
+/**
+ * Appends primitive values to a growable byte buffer, in little-endian
+ * order throughout. Pairs with {@link BinaryReader} for round-trip decoding.
+ *
+ * All multi-byte numeric fields (uint32, float64) use little-endian byte
+ * order. This is an internal implementation detail of the wire format —
+ * see `docs/BINARY_SERIALIZATION.md` for the full spec.
+ */
+export class BinaryWriter {
+  private chunks: Uint8Array[] = [];
+  private encoder = new TextEncoder();
+
+  /** Writes a single unsigned byte (0–255). */
+  writeUint8(value: number): this {
+    this.chunks.push(Uint8Array.of(value & 0xff));
+    return this;
+  }
+
+  /** Writes an unsigned 32-bit integer, little-endian. Used for lengths/counts. */
+  writeUint32(value: number): this {
+    const buf = new Uint8Array(4);
+    new DataView(buf.buffer).setUint32(0, value, true);
+    this.chunks.push(buf);
+    return this;
+  }
+
+  /**
+   * Writes a JS `number` as an IEEE-754 double (8 bytes, little-endian).
+   * Used instead of a fixed-width integer so timestamps and other numeric
+   * fields round-trip exactly without range/precision assumptions.
+   */
+  writeFloat64(value: number): this {
+    const buf = new Uint8Array(8);
+    new DataView(buf.buffer).setFloat64(0, value, true);
+    this.chunks.push(buf);
+    return this;
+  }
+
+  /** Writes a boolean as a single byte (0x00 | 0x01). */
+  writeBool(value: boolean): this {
+    return this.writeUint8(value ? 1 : 0);
+  }
+
+  /**
+   * Writes a non-negative bigint as a uint32 byte-length prefix followed by
+   * its minimal big-endian magnitude bytes. Zero is encoded as a
+   * zero-length field (no magnitude bytes).
+   */
+  writeBigInt(value: bigint): this {
+    if (value < 0n) {
+      throw new RangeError("writeBigInt does not support negative values");
+    }
+    if (value === 0n) {
+      return this.writeUint32(0);
+    }
+    const bytes: number[] = [];
+    let remaining = value;
+    while (remaining > 0n) {
+      bytes.unshift(Number(remaining & 0xffn));
+      remaining >>= 8n;
+    }
+    this.writeUint32(bytes.length);
+    this.chunks.push(Uint8Array.from(bytes));
+    return this;
+  }
+
+  /**
+   * Writes a UTF-8 string as a uint32 byte-length prefix followed by its
+   * encoded bytes.
+   */
+  writeString(value: string): this {
+    const encoded = this.encoder.encode(value);
+    this.writeUint32(encoded.length);
+    this.chunks.push(encoded);
+    return this;
+  }
+
+  /** Writes an array of strings as a uint32 count followed by each string. */
+  writeStringArray(values: readonly string[]): this {
+    this.writeUint32(values.length);
+    for (const value of values) {
+      this.writeString(value);
+    }
+    return this;
+  }
+
+  /** Concatenates all written chunks into a single contiguous buffer. */
+  toBytes(): Uint8Array {
+    const total = this.chunks.reduce((sum, chunk) => sum + chunk.length, 0);
+    const out = new Uint8Array(total);
+    let offset = 0;
+    for (const chunk of this.chunks) {
+      out.set(chunk, offset);
+      offset += chunk.length;
+    }
+    return out;
+  }
+}

--- a/packages/core/src/serialization/commitmentSerialization.ts
+++ b/packages/core/src/serialization/commitmentSerialization.ts
@@ -1,0 +1,90 @@
+import { BinaryWriter } from "./BinaryWriter";
+import { BinaryReader } from "./BinaryReader";
+import { SerializationError } from "./errors";
+import { PayloadTypeTag, SERIALIZATION_FORMAT_VERSION } from "./proofSerialization";
+import { CommitmentEntry, CommitRequest } from "../clients/types";
+
+function writeHeader(writer: BinaryWriter, tag: number): void {
+  writer.writeUint8(SERIALIZATION_FORMAT_VERSION).writeUint8(tag);
+}
+
+function readHeader(reader: BinaryReader, expectedTag: number): void {
+  const version = reader.readUint8();
+  if (version !== SERIALIZATION_FORMAT_VERSION) {
+    throw new SerializationError(
+      `Unsupported serialization format version ${version} (expected ${SERIALIZATION_FORMAT_VERSION}).`,
+      "SERIALIZATION_VERSION_MISMATCH"
+    );
+  }
+  const tag = reader.readUint8();
+  if (tag !== expectedTag) {
+    throw new SerializationError(
+      `Payload type tag mismatch: expected 0x${expectedTag.toString(16)}, got 0x${tag.toString(16)}.`,
+      "SERIALIZATION_TYPE_MISMATCH"
+    );
+  }
+}
+
+/**
+ * Encodes a {@link CommitmentEntry} (a salary commitment as stored/returned
+ * by the contract, including reveal state) into a binary-safe buffer.
+ */
+export function encodeCommitmentEntry(entry: CommitmentEntry): Uint8Array {
+  const writer = new BinaryWriter();
+  writeHeader(writer, PayloadTypeTag.COMMITMENT_ENTRY);
+  writer
+    .writeString(entry.employer)
+    .writeString(entry.employee)
+    .writeString(entry.commitmentHash)
+    .writeBigInt(entry.cycleId)
+    .writeFloat64(entry.createdAt)
+    .writeBool(entry.revealed)
+    .writeBigInt(entry.actualAmount);
+  return writer.toBytes();
+}
+
+/** Decodes a buffer produced by {@link encodeCommitmentEntry} back into a {@link CommitmentEntry}. */
+export function decodeCommitmentEntry(bytes: Uint8Array): CommitmentEntry {
+  const reader = new BinaryReader(bytes);
+  readHeader(reader, PayloadTypeTag.COMMITMENT_ENTRY);
+  const entry: CommitmentEntry = {
+    employer: reader.readString(),
+    employee: reader.readString(),
+    commitmentHash: reader.readString(),
+    cycleId: reader.readBigInt(),
+    createdAt: reader.readFloat64(),
+    revealed: reader.readBool(),
+    actualAmount: reader.readBigInt(),
+  };
+  reader.assertExhausted();
+  return entry;
+}
+
+/**
+ * Encodes a {@link CommitRequest} (the payload sent to commit a salary
+ * hash on-chain) into a binary-safe buffer.
+ */
+export function encodeCommitRequest(request: CommitRequest): Uint8Array {
+  const writer = new BinaryWriter();
+  writeHeader(writer, PayloadTypeTag.COMMIT_REQUEST);
+  writer
+    .writeString(request.employer)
+    .writeString(request.employee)
+    .writeString(request.commitmentHash)
+    .writeBigInt(request.cycleId);
+  return writer.toBytes();
+}
+
+/** Decodes a buffer produced by {@link encodeCommitRequest} back into a {@link CommitRequest}. */
+export function decodeCommitRequest(bytes: Uint8Array): CommitRequest {
+  const reader = new BinaryReader(bytes);
+  readHeader(reader, PayloadTypeTag.COMMIT_REQUEST);
+  const request: CommitRequest = {
+    employer: reader.readString(),
+    employee: reader.readString(),
+    commitmentHash: reader.readString(),
+    cycleId: reader.readBigInt(),
+  };
+  reader.assertExhausted();
+  return request;
+}

--- a/packages/core/src/serialization/errors.ts
+++ b/packages/core/src/serialization/errors.ts
@@ -1,0 +1,12 @@
+import { ZkPayrollError, ErrorContext } from "../core/errors";
+
+/**
+ * Thrown when binary encoding or decoding of a proof/commitment payload
+ * fails — truncated buffers, type-tag mismatches, or unsupported format
+ * versions.
+ */
+export class SerializationError extends ZkPayrollError {
+  constructor(message: string, code: string = "SERIALIZATION_FAILED", context: ErrorContext = {}) {
+    super(message, code, context);
+  }
+}

--- a/packages/core/src/serialization/index.ts
+++ b/packages/core/src/serialization/index.ts
@@ -1,0 +1,18 @@
+export { BinaryWriter } from "./BinaryWriter";
+export { BinaryReader } from "./BinaryReader";
+export { SerializationError } from "./errors";
+export {
+  SERIALIZATION_FORMAT_VERSION,
+  PayloadTypeTag,
+  encodeProofPayload,
+  decodeProofPayload,
+  encodeProofStruct,
+  decodeProofStruct,
+} from "./proofSerialization";
+export type { PayloadTypeTagValue } from "./proofSerialization";
+export {
+  encodeCommitmentEntry,
+  decodeCommitmentEntry,
+  encodeCommitRequest,
+  decodeCommitRequest,
+} from "./commitmentSerialization";

--- a/packages/core/src/serialization/proofSerialization.ts
+++ b/packages/core/src/serialization/proofSerialization.ts
@@ -1,0 +1,119 @@
+import { BinaryWriter } from "./BinaryWriter";
+import { BinaryReader } from "./BinaryReader";
+import { SerializationError } from "./errors";
+import { ProofPayload } from "../crypto/IProofGenerator";
+import { ProofStruct } from "../clients/types";
+
+/** Current binary wire-format version. Bump on breaking layout changes. */
+export const SERIALIZATION_FORMAT_VERSION = 1;
+
+/**
+ * Single-byte tags identifying which payload shape follows the version
+ * byte. Decoders verify the tag matches the type they were asked to
+ * decode, so a buffer encoded as one payload kind can't silently be
+ * misread as another.
+ */
+export const PayloadTypeTag = {
+  PROOF_PAYLOAD: 0x01,
+  PROOF_STRUCT: 0x02,
+  COMMITMENT_ENTRY: 0x03,
+  COMMIT_REQUEST: 0x04,
+} as const;
+
+export type PayloadTypeTagValue = (typeof PayloadTypeTag)[keyof typeof PayloadTypeTag];
+
+function writeHeader(writer: BinaryWriter, tag: PayloadTypeTagValue): void {
+  writer.writeUint8(SERIALIZATION_FORMAT_VERSION).writeUint8(tag);
+}
+
+function readHeader(reader: BinaryReader, expectedTag: PayloadTypeTagValue): void {
+  const version = reader.readUint8();
+  if (version !== SERIALIZATION_FORMAT_VERSION) {
+    throw new SerializationError(
+      `Unsupported serialization format version ${version} (expected ${SERIALIZATION_FORMAT_VERSION}).`,
+      "SERIALIZATION_VERSION_MISMATCH"
+    );
+  }
+  const tag = reader.readUint8();
+  if (tag !== expectedTag) {
+    throw new SerializationError(
+      `Payload type tag mismatch: expected 0x${expectedTag.toString(16)}, got 0x${tag.toString(16)}.`,
+      "SERIALIZATION_TYPE_MISMATCH"
+    );
+  }
+}
+
+/** Writes the shared Groth16 proof triple (pi_a, pi_b, pi_c) as field-element strings. */
+function writeProofTriple(
+  writer: BinaryWriter,
+  pi_a: [string, string],
+  pi_b: [[string, string], [string, string]],
+  pi_c: [string, string]
+): void {
+  writer.writeString(pi_a[0]).writeString(pi_a[1]);
+  writer.writeString(pi_b[0][0]).writeString(pi_b[0][1]);
+  writer.writeString(pi_b[1][0]).writeString(pi_b[1][1]);
+  writer.writeString(pi_c[0]).writeString(pi_c[1]);
+}
+
+function readProofTriple(reader: BinaryReader): {
+  pi_a: [string, string];
+  pi_b: [[string, string], [string, string]];
+  pi_c: [string, string];
+} {
+  const pi_a: [string, string] = [reader.readString(), reader.readString()];
+  const pi_b: [[string, string], [string, string]] = [
+    [reader.readString(), reader.readString()],
+    [reader.readString(), reader.readString()],
+  ];
+  const pi_c: [string, string] = [reader.readString(), reader.readString()];
+  return { pi_a, pi_b, pi_c };
+}
+
+/**
+ * Encodes a {@link ProofPayload} (the snarkjs-shaped proof, including
+ * protocol/curve metadata) into a binary-safe buffer.
+ */
+export function encodeProofPayload(payload: ProofPayload): Uint8Array {
+  const writer = new BinaryWriter();
+  writeHeader(writer, PayloadTypeTag.PROOF_PAYLOAD);
+  writeProofTriple(writer, payload.proof.pi_a, payload.proof.pi_b, payload.proof.pi_c);
+  writer.writeString(payload.proof.protocol);
+  writer.writeString(payload.proof.curve);
+  writer.writeStringArray(payload.publicSignals);
+  return writer.toBytes();
+}
+
+/** Decodes a buffer produced by {@link encodeProofPayload} back into a {@link ProofPayload}. */
+export function decodeProofPayload(bytes: Uint8Array): ProofPayload {
+  const reader = new BinaryReader(bytes);
+  readHeader(reader, PayloadTypeTag.PROOF_PAYLOAD);
+  const { pi_a, pi_b, pi_c } = readProofTriple(reader);
+  const protocol = reader.readString();
+  const curve = reader.readString();
+  const publicSignals = reader.readStringArray();
+  reader.assertExhausted();
+  return { proof: { pi_a, pi_b, pi_c, protocol, curve }, publicSignals };
+}
+
+/**
+ * Encodes a {@link ProofStruct} (the client/contract-level proof shape,
+ * without protocol/curve metadata) into a binary-safe buffer.
+ */
+export function encodeProofStruct(struct: ProofStruct): Uint8Array {
+  const writer = new BinaryWriter();
+  writeHeader(writer, PayloadTypeTag.PROOF_STRUCT);
+  writeProofTriple(writer, struct.pi_a, struct.pi_b, struct.pi_c);
+  writer.writeStringArray(struct.publicSignals);
+  return writer.toBytes();
+}
+
+/** Decodes a buffer produced by {@link encodeProofStruct} back into a {@link ProofStruct}. */
+export function decodeProofStruct(bytes: Uint8Array): ProofStruct {
+  const reader = new BinaryReader(bytes);
+  readHeader(reader, PayloadTypeTag.PROOF_STRUCT);
+  const { pi_a, pi_b, pi_c } = readProofTriple(reader);
+  const publicSignals = reader.readStringArray();
+  reader.assertExhausted();
+  return { pi_a, pi_b, pi_c, publicSignals };
+}

--- a/packages/core/tests/binary-serialization.test.ts
+++ b/packages/core/tests/binary-serialization.test.ts
@@ -1,0 +1,146 @@
+import {
+  encodeProofPayload,
+  decodeProofPayload,
+  encodeProofStruct,
+  decodeProofStruct,
+  encodeCommitmentEntry,
+  decodeCommitmentEntry,
+  encodeCommitRequest,
+  decodeCommitRequest,
+  SerializationError,
+  PayloadTypeTag,
+  SERIALIZATION_FORMAT_VERSION,
+} from "../src/serialization";
+
+import {
+  PROOF_PAYLOAD_NORMAL,
+  PROOF_PAYLOAD_MULTI,
+  PROOF_PAYLOAD_EDGE,
+  PROOF_STRUCT_NORMAL,
+  PROOF_STRUCT_MULTI,
+  PROOF_STRUCT_EDGE,
+} from "./fixtures/proof-request-fixtures";
+
+import {
+  COMMITMENT_ENTRY_NORMAL,
+  COMMITMENT_ENTRY_REVEALED,
+  COMMITMENT_ENTRY_EDGE,
+  COMMIT_REQUEST_NORMAL,
+  COMMIT_REQUEST_EDGE,
+} from "./fixtures/commitment-fixtures";
+
+describe("Binary serialization — ProofPayload", () => {
+  it.each([
+    ["normal", PROOF_PAYLOAD_NORMAL],
+    ["multi-signal", PROOF_PAYLOAD_MULTI],
+    ["edge-case values", PROOF_PAYLOAD_EDGE],
+  ])("round-trips a %s payload", (_label, payload) => {
+    const bytes = encodeProofPayload(payload);
+    expect(bytes).toBeInstanceOf(Uint8Array);
+    expect(decodeProofPayload(bytes)).toEqual(payload);
+  });
+
+  it("produces a binary-safe buffer, not a JSON/text encoding", () => {
+    const bytes = encodeProofPayload(PROOF_PAYLOAD_NORMAL);
+    // Byte 0 is the format version, byte 1 is the type tag — neither is
+    // printable JSON syntax like '{' (0x7b) or '"' (0x22).
+    expect(bytes[0]).toBe(SERIALIZATION_FORMAT_VERSION);
+    expect(bytes[1]).toBe(PayloadTypeTag.PROOF_PAYLOAD);
+  });
+
+  it("round-trips an empty publicSignals array", () => {
+    const payload = { ...PROOF_PAYLOAD_NORMAL, publicSignals: [] };
+    expect(decodeProofPayload(encodeProofPayload(payload))).toEqual(payload);
+  });
+});
+
+describe("Binary serialization — ProofStruct", () => {
+  it.each([
+    ["normal", PROOF_STRUCT_NORMAL],
+    ["multi-signal", PROOF_STRUCT_MULTI],
+    ["edge-case values", PROOF_STRUCT_EDGE],
+  ])("round-trips a %s struct", (_label, struct) => {
+    const bytes = encodeProofStruct(struct);
+    expect(decodeProofStruct(bytes)).toEqual(struct);
+  });
+
+  it("rejects a buffer encoded as ProofPayload when decoding as ProofStruct", () => {
+    const bytes = encodeProofPayload(PROOF_PAYLOAD_NORMAL);
+    expect(() => decodeProofStruct(bytes)).toThrow(SerializationError);
+    expect(() => decodeProofStruct(bytes)).toThrow(/type tag mismatch/i);
+  });
+});
+
+describe("Binary serialization — CommitmentEntry", () => {
+  it.each([
+    ["normal", COMMITMENT_ENTRY_NORMAL],
+    ["revealed / large values", COMMITMENT_ENTRY_REVEALED],
+    ["edge-case empty values", COMMITMENT_ENTRY_EDGE],
+  ])("round-trips a %s entry", (_label, entry) => {
+    const bytes = encodeCommitmentEntry(entry);
+    expect(decodeCommitmentEntry(bytes)).toEqual(entry);
+  });
+
+  it("preserves bigint type and large magnitude across the round trip", () => {
+    const bytes = encodeCommitmentEntry(COMMITMENT_ENTRY_REVEALED);
+    const decoded = decodeCommitmentEntry(bytes);
+    expect(typeof decoded.cycleId).toBe("bigint");
+    expect(decoded.cycleId).toBe(18446744073709551615n);
+    expect(decoded.actualAmount).toBe(9007199254740993n);
+  });
+
+  it("preserves fractional timestamps exactly via float64 encoding", () => {
+    const bytes = encodeCommitmentEntry(COMMITMENT_ENTRY_REVEALED);
+    expect(decodeCommitmentEntry(bytes).createdAt).toBe(1893456000.5);
+  });
+});
+
+describe("Binary serialization — CommitRequest", () => {
+  it.each([
+    ["normal", COMMIT_REQUEST_NORMAL],
+    ["unicode / large cycleId", COMMIT_REQUEST_EDGE],
+  ])("round-trips a %s request", (_label, request) => {
+    const bytes = encodeCommitRequest(request);
+    expect(decodeCommitRequest(bytes)).toEqual(request);
+  });
+
+  it("rejects a CommitmentEntry buffer when decoding as CommitRequest", () => {
+    const bytes = encodeCommitmentEntry(COMMITMENT_ENTRY_NORMAL);
+    expect(() => decodeCommitRequest(bytes)).toThrow(SerializationError);
+  });
+});
+
+describe("Binary serialization — malformed input handling", () => {
+  it("throws on a truncated buffer instead of returning garbage", () => {
+    const bytes = encodeCommitRequest(COMMIT_REQUEST_NORMAL);
+    const truncated = bytes.slice(0, bytes.length - 5);
+    expect(() => decodeCommitRequest(truncated)).toThrow(SerializationError);
+    expect(() => decodeCommitRequest(truncated)).toThrow(/unexpected end of buffer/i);
+  });
+
+  it("throws on an empty buffer", () => {
+    expect(() => decodeProofStruct(new Uint8Array(0))).toThrow(SerializationError);
+  });
+
+  it("throws on an unsupported format version", () => {
+    const bytes = encodeProofStruct(PROOF_STRUCT_NORMAL);
+    const corrupted = Uint8Array.from(bytes);
+    corrupted[0] = 99; // not a real version
+    expect(() => decodeProofStruct(corrupted)).toThrow(/version/i);
+  });
+
+  it("throws on trailing bytes after a valid payload", () => {
+    const bytes = encodeCommitRequest(COMMIT_REQUEST_NORMAL);
+    const withTrailingJunk = new Uint8Array(bytes.length + 3);
+    withTrailingJunk.set(bytes);
+    withTrailingJunk.set([1, 2, 3], bytes.length);
+    expect(() => decodeCommitRequest(withTrailingJunk)).toThrow(/trailing/i);
+  });
+});
+
+describe("Binary serialization — cross-type isolation", () => {
+  it("assigns a unique tag to every payload type", () => {
+    const tags = Object.values(PayloadTypeTag);
+    expect(new Set(tags).size).toBe(tags.length);
+  });
+});

--- a/packages/core/tests/fixtures/commitment-fixtures.ts
+++ b/packages/core/tests/fixtures/commitment-fixtures.ts
@@ -1,0 +1,58 @@
+import { CommitmentEntry, CommitRequest } from "../../src/clients/types";
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CommitmentEntry fixtures
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** Standard unrevealed commitment entry. */
+export const COMMITMENT_ENTRY_NORMAL: CommitmentEntry = {
+  employer: "GAEMPLOYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  employee: "GAEMPLOYEE1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  commitmentHash: "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff",
+  cycleId: 7n,
+  createdAt: 1735689600,
+  revealed: false,
+  actualAmount: 0n,
+};
+
+/** Commitment entry after reveal, with a large actualAmount and cycleId. */
+export const COMMITMENT_ENTRY_REVEALED: CommitmentEntry = {
+  employer: "GBEMPLOYER0987654321ZYXWVUTSRQPONMLKJIHGFEDCBA",
+  employee: "GBEMPLOYEE0987654321ZYXWVUTSRQPONMLKJIHGFEDCBA",
+  commitmentHash: "ffeeddccbbaa99887766554433221100ffeeddccbbaa998877665544332211",
+  cycleId: 18446744073709551615n,
+  createdAt: 1893456000.5,
+  revealed: true,
+  actualAmount: 9007199254740993n,
+};
+
+/** Edge-case commitment entry: zero/empty values and cycleId of 0. */
+export const COMMITMENT_ENTRY_EDGE: CommitmentEntry = {
+  employer: "",
+  employee: "",
+  commitmentHash: "",
+  cycleId: 0n,
+  createdAt: 0,
+  revealed: false,
+  actualAmount: 0n,
+};
+
+// ═══════════════════════════════════════════════════════════════════════════════
+// CommitRequest fixtures
+// ═══════════════════════════════════════════════════════════════════════════════
+
+/** Standard commit request. */
+export const COMMIT_REQUEST_NORMAL: CommitRequest = {
+  employer: "GAEMPLOYER1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  employee: "GAEMPLOYEE1234567890ABCDEFGHIJKLMNOPQRSTUVWXYZ",
+  commitmentHash: "a1b2c3d4e5f60718293a4b5c6d7e8f90112233445566778899aabbccddeeff",
+  cycleId: 1n,
+};
+
+/** Commit request with a very large cycleId and unicode in addresses. */
+export const COMMIT_REQUEST_EDGE: CommitRequest = {
+  employer: "G\u00e9mployer-üñîçødé",
+  employee: "",
+  commitmentHash: "0x",
+  cycleId: 340282366920938463463374607431768211455n,
+};


### PR DESCRIPTION
Closes #62

---

## Summary

This PR adds reusable binary serialization helpers for proof- and commitment-related payloads in the SDK.

### Changes

- Added binary serialization and deserialization helpers for:
  - ProofPayload
  - ProofStruct
  - CommitmentEntry
  - CommitRequest
- Added serialization format versioning and payload type tags.
- Added validation for malformed or unsupported payloads.
- Added comprehensive round-trip tests covering representative payloads and edge cases.
- Added documentation describing the binary serialization format and expected payload structure.

### Tests

Added a dedicated test suite covering:

- Round-trip serialization/deserialization
- Binary-safe encoding
- Empty and edge-case payloads
- Large `bigint` values
- Unicode values
- Malformed/truncated buffers
- Unsupported format versions
- Cross-type decoding protection
- Trailing-byte validation

Test results:

```text
Test Suites: 1 passed, 1 total
Tests:       22 passed, 22 total
```

## Notes

While validating this change, the new binary serialization test suite passes successfully. The repository currently contains unrelated pre-existing TypeScript/test failures (for example in `src/errors.ts` and several existing test suites), which are outside the scope of this PR.