### PR TITLE
feat: add sdk transaction polling helper with timeout support (#155)

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -63,6 +63,7 @@ export * from "./testing";
 // ── Events ──────────────────────────────────────────────────────────────────
 export { TransactionWatcher } from "./events";
 export type { ConfirmationOptions, ConfirmationResult } from "./events";
+export * from "./polling";
 
 // ── Pagination Helpers ───────────────────────────────────────────────────────
 export * from "./pagination";

--- a/packages/core/src/polling.ts
+++ b/packages/core/src/polling.ts
@@ -1,0 +1,106 @@
+import { rpc } from "@stellar/stellar-sdk";
+import { ContractExecutionError, ContractErrorCode } from "./errors";
+
+export interface PollTransactionOptions {
+  /** Maximum time to wait in milliseconds. Default: 30000 (30 seconds) */
+  timeoutMs?: number;
+  /** Polling interval in milliseconds. Default: 2000 (2 seconds) */
+  intervalMs?: number;
+  /** Abort signal to cancel polling */
+  signal?: AbortSignal;
+}
+
+export type TransactionStatusResult =
+  | { status: "SUCCESS"; returnValue?: rpc.Api.GetSuccessfulTransactionResponse["returnValue"]; ledger?: number; txHash: string }
+  | { status: "FAILED"; txHash: string };
+
+/**
+ * Polls for transaction status until it succeeds, fails, or times out.
+ * 
+ * @param server The Stellar RPC Server instance
+ * @param txHash The transaction hash to poll
+ * @param options Polling configuration options including timeoutMs and intervalMs
+ * @returns The final transaction status
+ * @throws {ContractExecutionError} If the transaction times out
+ * @throws {Error} If polling is cancelled via AbortSignal or an RPC error occurs
+ */
+export async function pollTransaction(
+  server: rpc.Server,
+  txHash: string,
+  options: PollTransactionOptions = {}
+): Promise<TransactionStatusResult> {
+  const timeoutMs = options.timeoutMs ?? 30000;
+  const intervalMs = options.intervalMs ?? 2000;
+  const signal = options.signal;
+
+  const startTime = Date.now();
+
+  while (Date.now() - startTime < timeoutMs) {
+    if (signal?.aborted) {
+      throw new Error(`Polling for transaction ${txHash} was cancelled.`);
+    }
+
+    const response = await server.getTransaction(txHash);
+
+    if (response.status === rpc.Api.GetTransactionStatus.SUCCESS) {
+      const successResp = response as rpc.Api.GetSuccessfulTransactionResponse;
+      return {
+        status: "SUCCESS",
+        txHash,
+        returnValue: successResp.returnValue,
+        ledger: successResp.ledger,
+      };
+    }
+
+    if (response.status === rpc.Api.GetTransactionStatus.FAILED) {
+      return {
+        status: "FAILED",
+        txHash
+      };
+    }
+
+    // If NOT_FOUND, sleep and try again
+    try {
+      await sleep(intervalMs, signal);
+    } catch (err: any) {
+      if (err.message === "AbortError") {
+        throw new Error(`Polling for transaction ${txHash} was cancelled.`);
+      }
+      throw err;
+    }
+  }
+
+  throw new ContractExecutionError(
+    `Transaction ${txHash} timed out after ${timeoutMs}ms`,
+    ContractErrorCode.TRANSACTION_TIMEOUT
+  );
+}
+
+function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+  return new Promise((resolve, reject) => {
+    if (signal?.aborted) {
+      return reject(new Error("AbortError"));
+    }
+
+    const timer = setTimeout(() => {
+      cleanup();
+      resolve();
+    }, ms);
+
+    const onAbort = () => {
+      clearTimeout(timer);
+      cleanup();
+      reject(new Error("AbortError"));
+    };
+
+    if (signal) {
+      signal.addEventListener("abort", onAbort);
+    }
+
+    function cleanup() {
+      if (signal) {
+        signal.removeEventListener("abort", onAbort);
+      }
+    }
+  });
+}

--- a/packages/core/tests/polling.test.ts
+++ b/packages/core/tests/polling.test.ts
@@ -1,0 +1,118 @@
+import { rpc } from "@stellar/stellar-sdk";
+import { pollTransaction } from "../src/polling";
+import { ContractExecutionError, ContractErrorCode } from "../src/errors";
+
+function createMockServer(responses: rpc.Api.GetTransactionResponse[]): rpc.Server {
+  let callIndex = 0;
+  return {
+    getTransaction: jest.fn().mockImplementation(() => {
+      const response = responses[callIndex] ?? responses[responses.length - 1];
+      callIndex++;
+      return Promise.resolve(response);
+    }),
+  } as unknown as rpc.Server;
+}
+
+const SUCCESS_RESPONSE = {
+  status: rpc.Api.GetTransactionStatus.SUCCESS,
+  ledger: 12345,
+  returnValue: undefined,
+  createdAt: "2024-01-01T00:00:00Z",
+  oldestLedger: 1,
+  oldestLedgerCloseTime: "2024-01-01T00:00:00Z",
+  latestLedger: 12345,
+  latestLedgerCloseTime: "2024-01-01T00:00:00Z",
+  envelopeXdr: {} as never,
+  resultXdr: {} as never,
+  resultMetaXdr: {} as never,
+} as unknown as rpc.Api.GetSuccessfulTransactionResponse;
+
+const FAILED_RESPONSE = {
+  status: rpc.Api.GetTransactionStatus.FAILED,
+} as rpc.Api.GetFailedTransactionResponse;
+
+const NOT_FOUND_RESPONSE = {
+  status: rpc.Api.GetTransactionStatus.NOT_FOUND,
+} as rpc.Api.GetMissingTransactionResponse;
+
+describe("pollTransaction", () => {
+  it("returns SUCCESS status on successful transaction", async () => {
+    const server = createMockServer([SUCCESS_RESPONSE]);
+    
+    const result = await pollTransaction(server, "tx_hash_123", {
+      intervalMs: 10,
+    });
+
+    expect(result.status).toBe("SUCCESS");
+    expect(result.txHash).toBe("tx_hash_123");
+    if (result.status === "SUCCESS") {
+      expect(result.ledger).toBe(12345);
+    }
+  });
+
+  it("returns FAILED status on failed transaction", async () => {
+    const server = createMockServer([FAILED_RESPONSE]);
+    
+    const result = await pollTransaction(server, "tx_hash_fail", {
+      intervalMs: 10,
+    });
+
+    expect(result.status).toBe("FAILED");
+    expect(result.txHash).toBe("tx_hash_fail");
+  });
+
+  it("polls until transaction is found", async () => {
+    const server = createMockServer([NOT_FOUND_RESPONSE, NOT_FOUND_RESPONSE, SUCCESS_RESPONSE]);
+    
+    const result = await pollTransaction(server, "tx_hash_123", {
+      intervalMs: 10,
+    });
+
+    expect(result.status).toBe("SUCCESS");
+    expect(server.getTransaction).toHaveBeenCalledTimes(3);
+  });
+
+  it("throws ContractExecutionError on timeout", async () => {
+    const server = createMockServer([NOT_FOUND_RESPONSE]);
+    
+    await expect(
+      pollTransaction(server, "tx_hash_timeout", {
+        timeoutMs: 30, // short timeout
+        intervalMs: 10,
+      })
+    ).rejects.toThrow(ContractExecutionError);
+
+    await expect(
+      pollTransaction(server, "tx_hash_timeout", {
+        timeoutMs: 30,
+        intervalMs: 10,
+      })
+    ).rejects.toMatchObject({
+      code: ContractErrorCode.TRANSACTION_TIMEOUT,
+    });
+  });
+
+  it("throws Error if cancelled via AbortSignal", async () => {
+    const server = createMockServer([NOT_FOUND_RESPONSE]);
+    const controller = new AbortController();
+    
+    const promise = pollTransaction(server, "tx_hash_cancel", {
+      intervalMs: 50,
+      signal: controller.signal,
+    });
+
+    controller.abort();
+
+    await expect(promise).rejects.toThrow("cancelled");
+  });
+
+  it("propagates RPC errors", async () => {
+    const server = {
+      getTransaction: jest.fn().mockRejectedValue(new Error("RPC Network failure")),
+    } as unknown as rpc.Server;
+    
+    await expect(pollTransaction(server, "tx_hash", { intervalMs: 10 })).rejects.toThrow(
+      "RPC Network failure"
+    );
+  });
+});

--- a/src/api/index.ts
+++ b/src/api/index.ts
@@ -10,3 +10,5 @@ export { PayrollContract } from "../contract";
 export { DEFAULT_CONFIG, ConfigPresets, ConfigBuilder } from "../config";
 export type { ClientConfig } from "../config";
 export type { PayrollRecord, Network } from "../types";
+export { pollTransaction } from "../../packages/core/src/polling";
+export type { PollTransactionOptions, TransactionStatusResult } from "../../packages/core/src/polling";


### PR DESCRIPTION

**Title:** feat: add SDK transaction polling helper with timeout support

**Context:**
Integrators previously lacked a straightforward, bound-checked method for polling transaction completion states. Without timeouts, simple polling implementations can inadvertently turn into unbounded loops if the transaction falls off the network or experiences extended delays. This PR introduces a `pollTransaction` helper with built-in, configurable limits (e.g., `timeoutMs` and `intervalMs`) to ensure safe state tracking and improve developer confidence.

**Implementation Details:**
- **`pollTransaction` Helper:** Added a new generalized helper function in `packages/core/src/polling.ts` for polling a transaction hash until completion or timeout.
- **Configurable Limits:** Supports explicit configurations for `timeoutMs` (defaults to 30s) and `intervalMs` (defaults to 2s).
- **Cancellation Support:** Integrates seamlessly with `AbortSignal` for user-driven cancellation flows.
- **Clear Error Handlers:** Throws deterministic internal errors like `ContractExecutionError` with `TRANSACTION_TIMEOUT` error codes when the timeout occurs.
- **API Exports:** Added public exports for `pollTransaction` and its option interfaces via `src/api/index.ts`.

**Verification:**
- Wrote and passed comprehensive unit tests covering successful polls, failed status returns, timeouts, internal RPC errors, and manual cancellation via `AbortSignal`.
- The full test suite passing: `npx jest packages/core/tests/polling.test.ts`.

closes #155 
