### PR TITLE
docs: add Browser and Backend Usage section to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,6 +70,85 @@ await service.processPayment({
 - **Error Handling**: Robust error typing and management.
 - **Mock Testing Environment**: Comprehensive testing utilities for unit tests without a live network.
 
+## Browser and Backend Usage
+
+Use this section to pick the right environment before you wire the SDK into a product. The package supports **browsers** (wallets, dashboards) and **Node.js backends** (workers, automation), but secrets and signing paths differ.
+
+### Quick matrix
+
+| Concern | Browser (frontend) | Backend (Node worker / service) |
+|--------|--------------------|----------------------------------|
+| **Wallet signing** | User wallets (Freighter, Albedo) via adapters | Server-held keys from a secrets manager — **not** browser extensions |
+| **Proof generation** | On-device with snarkjs; prefer [Web Workers](./docs/WORKER_PROOF_GENERATION.md) so the UI stays responsive | On the worker/process for batch payroll; good for heavy or unattended jobs |
+| **Secrets / witnesses** | Never embed Stellar secret keys (`S…`) or long-lived note secrets in frontend code, env shipped to the client, or `localStorage` | Load signer material from env / KMS / secrets manager; never log full witnesses |
+| **Next.js / SSR** | Import SDK only in Client Components (`"use client"`) | Do not import the browser wallet path in Server Components or Route Handlers for UI signing |
+| **Best fit** | Employee/employer dashboards, interactive connect + sign | Payroll automation, queues, retries, multi-payment workers |
+
+Supported runtime versions: [Runtime Support Matrix](./docs/SUPPORT_MATRIX.md).
+
+### Browser (short guidance)
+
+Interactive apps should connect a wallet, generate or request proofs without blocking the main thread when possible, and keep sensitive material off the client bundle.
+
+```typescript
+// Frontend / Next.js Client Component — "use client"
+import { FreighterAdapter } from "@zk-payroll/sdk";
+
+const wallet = new FreighterAdapter();
+if (wallet.isAvailable()) {
+  const publicKey = await wallet.connect();
+  // Build XDR with public flows; sign via the adapter — never with a hardcoded secret key
+  // const signed = await wallet.signTransaction(xdr);
+}
+```
+
+- Prefer [Worker-based proof generation](./docs/WORKER_PROOF_GENERATION.md) for multi-second circuit work.
+- For App Router apps, follow [Next.js Integration](./docs/NEXTJS_INTEGRATION.md) (client boundary rules).
+- Wallet details: [Wallet Adapters](./docs/WALLET_ADAPTERS.md).
+
+### Backend (short guidance)
+
+Backend services own **automation**: queue jobs, generate proofs on the server, sign with keys that never leave the host, and submit to RPC.
+
+```typescript
+// Node worker — secrets from environment / secrets manager only
+import { PayrollService, ConfigPresets } from "@zk-payroll/sdk";
+
+const config = ConfigPresets.testnet()
+  .withContractId(process.env.CONTRACT_ID!)
+  .withProofConfig({
+    wasmUrl: process.env.WASM_URL!,
+    zkeyUrl: process.env.ZKEY_URL!,
+  })
+  .build();
+
+const service = new PayrollService(config);
+// Signer secret: process.env / KMS — never commit S… keys or put them in browser env
+```
+
+- End-to-end worker prototype: [Backend Worker Quickstart](./docs/BACKEND_WORKER_QUICKSTART.md).
+- Production patterns (config, secret handling, retries): [Backend Integration Guide](./docs/BACKEND_INTEGRATION_GUIDE.md).
+
+### Secret handling (both environments)
+
+| Do | Don't |
+|----|--------|
+| Keep note `secret` / nullifier inputs in memory only as long as needed for proving | Log witnesses, proofs with private inputs, or secret keys |
+| Use HTTPS CDN or authenticated artifact hosts for `.wasm` / `.zkey` | Ship production signing keys in frontend env (`NEXT_PUBLIC_*`, Vite `VITE_*`, etc.) |
+| Rotate and scope backend signer keys; prefer HSM/KMS where possible | Reuse a single hot key across untrusted multi-tenant frontends |
+
+Proof APIs and witness shapes: [ZK Proof Generation](./docs/ZK_PROOF_GENERATION.md).
+
+### Related docs
+
+- [Runtime Support Matrix](./docs/SUPPORT_MATRIX.md)
+- [Wallet Adapters](./docs/WALLET_ADAPTERS.md)
+- [ZK Proof Generation](./docs/ZK_PROOF_GENERATION.md)
+- [Worker Proof Generation](./docs/WORKER_PROOF_GENERATION.md)
+- [Next.js Integration](./docs/NEXTJS_INTEGRATION.md)
+- [Backend Worker Quickstart](./docs/BACKEND_WORKER_QUICKSTART.md)
+- [Backend Integration Guide](./docs/BACKEND_INTEGRATION_GUIDE.md)
+
 ## Zero-Knowledge Proof Generation
 
 The SDK includes production-ready ZK proof generation using snarkjs:
@@ -369,6 +448,7 @@ patterns for tests, and rules for extending the registry in production.
 ## Documentation
 
 - [Runtime Support Matrix](./docs/SUPPORT_MATRIX.md) - Supported Node.js and browser versions
+- [Browser and Backend Usage](#browser-and-backend-usage) - Where to run the SDK, wallets, proofs, and secrets
 - [API Reference](./docs/API.md) - Complete API documentation
 - [Error Handling](./docs/ERRORS.md) - Public error hierarchy and recovery patterns
 - [ZK Proof Generation](./docs/ZK_PROOF_GENERATION.md) - Detailed proof generation guide


### PR DESCRIPTION
## Summary

I added a **Browser and Backend Usage** section to the SDK README so integrators can see, up front, what belongs in the browser versus a Node backend.

I only tackled issue #159 (documentation). I did not change runtime code, examples, or other docs files beyond linking them from the README.

## What I covered

- Quick matrix: wallet signing, proof generation, secrets, Next.js/SSR, best fit
- Short browser guidance (wallet adapter + worker proofs pointer)
- Short backend guidance (env/KMS secrets, worker pattern)
- Explicit secret-handling do/don't table
- Links to existing guides (support matrix, wallets, ZK proofs, workers, Next.js, backend)

## Related Issue

Closes #159

## Test plan

- [x] README renders the new section and anchor link under Documentation
- [x] Linked paths under `docs/` exist in the repo
- [ ] Maintainer skim for accuracy against current SDK exports

## Scope

I only resolved #159. No other issues, refactors, or package changes.