### PR TITLE
feat: add payroll payload normalizer

### DIFF
--- a/README.md
+++ b/README.md
@@ -297,6 +297,31 @@ const isValid = await client.verifyCommitment("G...", "G...", 1n, proof, signer)
 await client.revealSalary("G...", "G...", 1n, 1000n, signer);
 ```
 
+## Payload Normalization
+
+Consumers rarely pass payroll data in exactly one shape (different key names, extra whitespace, comma-formatted amounts, mixed-case addresses). `normalizePayrollPayload` converts any of these variations into the SDK's canonical entry shape before validation, proof preparation, or transaction building:
+
+```typescript
+import { normalizePayrollPayload } from "@zk-payroll/sdk";
+
+const { entries, issues } = normalizePayrollPayload({
+  entries: [
+    { employee_id: "  E-42  ", wallet: "gabc...", asset: "xlm", amount: "1,000.50" },
+  ],
+});
+
+// entries[0] => { employeeId: "E-42", walletAddress: "GABC...", asset: "native", amount: "1000.50", source: {...} }
+
+// Required fields (employeeId, walletAddress, asset, amount) are never silently dropped —
+// missing/unparseable data shows up as an indexed issue instead, with the original
+// input still reachable via entries[issue.index].source.raw for clear validation errors.
+if (issues.length > 0) {
+  console.log(issues);
+}
+```
+
+See the [Payload Normalization Guide](./docs/PAYLOAD_NORMALIZATION.md) for the full field-by-field normalization rules.
+
 ## Batch Payload Validation
 
 The SDK automatically validates batch payroll payloads before submitting them to contracts, preventing empty batches, duplicate recipients, and invalid amounts:
@@ -449,6 +474,7 @@ patterns for tests, and rules for extending the registry in production.
 
 - [Runtime Support Matrix](./docs/SUPPORT_MATRIX.md) - Supported Node.js and browser versions
 - [Browser and Backend Usage](#browser-and-backend-usage) - Where to run the SDK, wallets, proofs, and secrets
+- [Payload Normalization](./docs/PAYLOAD_NORMALIZATION.md) - Canonicalizing payroll payloads before validation
 - [API Reference](./docs/API.md) - Complete API documentation
 - [Error Handling](./docs/ERRORS.md) - Public error hierarchy and recovery patterns
 - [ZK Proof Generation](./docs/ZK_PROOF_GENERATION.md) - Detailed proof generation guide

--- a/docs/PAYLOAD_NORMALIZATION.md
+++ b/docs/PAYLOAD_NORMALIZATION.md
@@ -1,0 +1,103 @@
+# Payroll Payload Normalization
+
+SDK consumers rarely hand the SDK data in exactly one shape: key names vary
+(`recipient` vs. `walletAddress` vs. `wallet`), amounts arrive as
+comma-formatted strings or raw numbers, addresses get pasted in lowercase,
+and fields carry stray whitespace from a CSV import. `normalizePayrollPayload`
+converts any of these variations into one canonical shape before validation,
+proof preparation, or transaction building — so the rest of the SDK only
+ever has to reason about one format.
+
+## Core concepts
+
+| Concept | What it is |
+|---|---|
+| `RawPayrollEntry` | The loosely-typed shape a consumer may supply — several key aliases are accepted per field. |
+| `CanonicalPayrollEntry` | The normalized, internal shape: trimmed `employeeId`, uppercased `walletAddress`, canonical `asset`/`amount` strings, optional `period`/`department`, and a `source` back-reference. |
+| `NormalizationIssue` | A record of a required field that could not be cleanly resolved, tagged with the entry's original index. |
+| `normalizePayrollPayload` | Converts a `RawPayrollPayload` (`{ entries: RawPayrollEntry[] }`) into a `NormalizedPayrollPayload` (`{ entries, issues }`). |
+
+```ts
+import { normalizePayrollPayload } from "@zk-payroll/core";
+
+const { entries, issues } = normalizePayrollPayload({
+  entries: [
+    { employee_id: "  E-42  ", wallet: "gabc123def", asset: "xlm", amount: "1,000.50" },
+  ],
+});
+
+console.log(entries[0]);
+// {
+//   employeeId: "E-42",
+//   walletAddress: "GABC123DEF",
+//   asset: "native",
+//   amount: "1000.50",
+//   source: { index: 0, raw: { employee_id: "  E-42  ", wallet: "gabc123def", ... } },
+// }
+console.log(issues); // []
+```
+
+## Field normalization rules
+
+| Canonical field | Accepted aliases | What normalization does |
+|---|---|---|
+| `employeeId` | `employeeId`, `employee_id`, `id` | Coerces string/number/bigint input, trims whitespace. |
+| `walletAddress` | `recipient`, `walletAddress`, `wallet_address`, `wallet`, `address` | Trims whitespace, uppercases (Stellar strkeys are always uppercase). |
+| `asset` | `asset`, `assetId`, `asset_id`, `token` | Trims whitespace; collapses `"xlm"` / `"lumens"` (any casing) to the SDK's reserved `"native"` id. Contract-ID-style values are trimmed only — their casing is significant and left untouched. |
+| `period` (optional) | `period`, `periodId`, `period_id`, `payPeriod` | Trims whitespace. Omitted entirely from the canonical entry when not supplied — no issue is raised. |
+| `amount` | `amount`, `salaryAmount`, `salary_amount` | Stringifies `bigint`/`number` input; for strings, strips thousands separators, currency symbols (`$€£¥`), and internal/surrounding whitespace, and drops a redundant leading `+`. |
+
+`department` is passed through as a trimmed string when present and omitted
+otherwise; the SDK does not interpret it further.
+
+When more than one alias is present on the same raw entry, the first match
+(in the order listed above) wins.
+
+## Required fields and issues
+
+`employeeId`, `walletAddress`, `asset`, and `amount` are required. Normalization
+never throws and never drops an entry: every input entry produces exactly one
+canonical entry, in the same order, even when required data is missing or
+malformed.
+
+- If a required field has no usable value, the canonical field is set to
+  `""` and a `NormalizationIssue` with `code: "MISSING"` is recorded for that
+  entry's index.
+- If `amount` normalizes to a non-numeric string (e.g. `"not-a-number"`),
+  the cleaned string is still kept on the canonical entry, but a
+  `NormalizationIssue` with `code: "UNPARSEABLE_AMOUNT"` is recorded so the
+  bad value stays visible instead of silently passing through.
+
+```ts
+const { entries, issues } = normalizePayrollPayload({
+  entries: [{ period: "2025-Q2-P1" }], // missing employeeId, walletAddress, asset, amount
+});
+
+entries[0]; // { employeeId: "", walletAddress: "", asset: "", amount: "", period: "2025-Q2-P1", source: {...} }
+issues;     // 4 MISSING issues, one per required field, all with index: 0
+```
+
+Run `normalizePayrollPayload` before validation and treat any entry whose
+index appears in `issues` as invalid — validation should not need to
+re-discover that the data was missing.
+
+## Preserving original input for validation errors
+
+Every canonical entry carries a `source: { index, raw }` back-reference to
+the exact object it was derived from. Validation code that rejects a
+normalized entry can use `source.index` and `source.raw` to point a caller
+back at *their* original input — including the original casing, whitespace,
+and key names — rather than only showing the cleaned-up canonical value.
+
+```ts
+for (const issue of issues) {
+  const original = entries[issue.index].source.raw;
+  console.warn(`Entry ${issue.index} (${issue.field}): ${issue.message}`, original);
+}
+```
+
+## Already-normalized payloads
+
+Payloads that already match the canonical shape (uppercase addresses,
+plain decimal amount strings, `"native"` for XLM) pass through unchanged —
+normalization is idempotent for well-formed input.

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -107,3 +107,6 @@ export * from "./redaction";
 
 // ── Multi-Asset Metadata ────────────────────────────────────────────────────
 export * from "./assets";
+
+// ── Payload Normalization ───────────────────────────────────────────────────
+export * from "./normalization";

--- a/packages/core/src/normalization/index.ts
+++ b/packages/core/src/normalization/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Payroll payload normalization.
+ *
+ * Converts user-provided payroll payloads (varying key names, whitespace,
+ * casing, amount formatting) into the SDK's canonical shape before
+ * validation, proof preparation, or transaction building.
+ *
+ * ```ts
+ * import { normalizePayrollPayload } from "@zk-payroll/core";
+ *
+ * const { entries, issues } = normalizePayrollPayload({
+ *   entries: [{ employee_id: " E-1 ", wallet: "gabc...", asset: "xlm", amount: "1,000.50" }],
+ * });
+ * ```
+ */
+export * from "./types";
+export * from "./normalizer";

--- a/packages/core/src/normalization/normalizer.ts
+++ b/packages/core/src/normalization/normalizer.ts
@@ -1,0 +1,196 @@
+import {
+  CanonicalPayrollEntry,
+  NormalizationIssue,
+  NormalizedPayrollPayload,
+  RawPayrollEntry,
+  RawPayrollPayload,
+} from "./types";
+
+const EMPLOYEE_ID_KEYS = ["employeeId", "employee_id", "id"];
+const WALLET_ADDRESS_KEYS = ["recipient", "walletAddress", "wallet_address", "wallet", "address"];
+const ASSET_KEYS = ["asset", "assetId", "asset_id", "token"];
+const PERIOD_KEYS = ["period", "periodId", "period_id", "payPeriod"];
+const AMOUNT_KEYS = ["amount", "salaryAmount", "salary_amount"];
+
+/** Aliases that collapse to the SDK's reserved native-asset identifier. */
+const NATIVE_ASSET_ALIASES = new Set(["native", "xlm", "lumens"]);
+
+const NUMERIC_AMOUNT_PATTERN = /^-?\d+(\.\d+)?$/;
+
+/** Returns the first defined, non-null value among `keys` on `entry`. */
+function pick(entry: RawPayrollEntry, keys: string[]): unknown {
+  for (const key of keys) {
+    const value = entry[key];
+    if (value !== undefined && value !== null) {
+      return value;
+    }
+  }
+  return undefined;
+}
+
+/** Coerces string/number/bigint input to a string; anything else is unusable. */
+function coerceString(value: unknown): string | undefined {
+  if (typeof value === "string") return value;
+  if (typeof value === "number" || typeof value === "bigint") return value.toString();
+  return undefined;
+}
+
+/**
+ * Normalizes an employee identifier: coerces to string and trims whitespace.
+ * Returns `undefined` when no usable value was supplied.
+ */
+export function normalizeEmployeeId(value: unknown): string | undefined {
+  const trimmed = coerceString(value)?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Normalizes a wallet address: coerces to string, trims whitespace, and
+ * uppercases it (Stellar strkeys are always uppercase). Returns `undefined`
+ * when no usable value was supplied.
+ */
+export function normalizeWalletAddress(value: unknown): string | undefined {
+  const trimmed = coerceString(value)?.trim();
+  return trimmed ? trimmed.toUpperCase() : undefined;
+}
+
+/**
+ * Normalizes an asset identifier: coerces to string, trims whitespace, and
+ * collapses common XLM aliases (`"xlm"`, `"lumens"`, any casing) to the SDK's
+ * reserved `"native"` identifier. Any other value (e.g. a Soroban contract
+ * ID) is trimmed but otherwise left untouched, since its casing is
+ * significant. Returns `undefined` when no usable value was supplied.
+ */
+export function normalizeAssetId(value: unknown): string | undefined {
+  const trimmed = coerceString(value)?.trim();
+  if (!trimmed) return undefined;
+  return NATIVE_ASSET_ALIASES.has(trimmed.toLowerCase()) ? "native" : trimmed;
+}
+
+/**
+ * Normalizes a payroll period identifier: coerces to string and trims
+ * whitespace. Returns `undefined` when no usable value was supplied.
+ */
+export function normalizePeriod(value: unknown): string | undefined {
+  const trimmed = coerceString(value)?.trim();
+  return trimmed ? trimmed : undefined;
+}
+
+/**
+ * Normalizes an amount to a canonical numeric string: `bigint`/`number`
+ * inputs are stringified; string inputs have thousands separators, currency
+ * symbols, and surrounding/internal whitespace stripped, and a redundant
+ * leading `+` removed.
+ *
+ * This does not validate that the result is numeric — {@link
+ * normalizePayrollPayload} records an `UNPARSEABLE_AMOUNT` issue for results
+ * that don't look like a plain decimal number, while still preserving the
+ * cleaned string so validation errors can reference what was supplied.
+ *
+ * Returns `undefined` when no usable value was supplied.
+ */
+export function normalizeAmount(value: unknown): string | undefined {
+  if (typeof value === "bigint") return value.toString();
+  if (typeof value === "number") return Number.isFinite(value) ? value.toString() : undefined;
+  if (typeof value !== "string") return undefined;
+
+  const cleaned = value
+    .trim()
+    .replace(/[$€£¥]/g, "")
+    .replace(/,/g, "")
+    .replace(/\s+/g, "")
+    .replace(/^\+/, "");
+
+  return cleaned ? cleaned : undefined;
+}
+
+/**
+ * Converts a user-provided payroll payload into the SDK's canonical shape.
+ *
+ * Normalization is deliberately non-throwing: every input entry produces
+ * exactly one canonical entry, in the same order, even when required fields
+ * are missing or malformed. Problems are instead surfaced via the returned
+ * `issues` array (indexed and field-tagged) and by preserving each entry's
+ * original input under `source`, so validation run afterward can still
+ * produce clear, positioned errors — normalization never silently drops
+ * required data.
+ *
+ * @example
+ * ```ts
+ * const { entries, issues } = normalizePayrollPayload({
+ *   entries: [
+ *     { employee_id: "  E-1  ", wallet: "gabc...", asset: "XLM", amount: "1,000.50" },
+ *   ],
+ * });
+ * // entries[0] => { employeeId: "E-1", walletAddress: "GABC...", asset: "native", amount: "1000.50", ... }
+ * ```
+ */
+export function normalizePayrollPayload(input: RawPayrollPayload): NormalizedPayrollPayload {
+  const entries: CanonicalPayrollEntry[] = [];
+  const issues: NormalizationIssue[] = [];
+
+  input.entries.forEach((raw, index) => {
+    const employeeId = normalizeEmployeeId(pick(raw, EMPLOYEE_ID_KEYS));
+    if (employeeId === undefined) {
+      issues.push({
+        index,
+        field: "employeeId",
+        code: "MISSING",
+        message: "Employee id is required but was missing or empty.",
+      });
+    }
+
+    const walletAddress = normalizeWalletAddress(pick(raw, WALLET_ADDRESS_KEYS));
+    if (walletAddress === undefined) {
+      issues.push({
+        index,
+        field: "walletAddress",
+        code: "MISSING",
+        message: "Wallet address is required but was missing or empty.",
+      });
+    }
+
+    const asset = normalizeAssetId(pick(raw, ASSET_KEYS));
+    if (asset === undefined) {
+      issues.push({
+        index,
+        field: "asset",
+        code: "MISSING",
+        message: "Asset identifier is required but was missing or empty.",
+      });
+    }
+
+    const rawAmount = pick(raw, AMOUNT_KEYS);
+    const amount = normalizeAmount(rawAmount);
+    if (amount === undefined) {
+      issues.push({
+        index,
+        field: "amount",
+        code: "MISSING",
+        message: "Amount is required but was missing or empty.",
+      });
+    } else if (!NUMERIC_AMOUNT_PATTERN.test(amount)) {
+      issues.push({
+        index,
+        field: "amount",
+        code: "UNPARSEABLE_AMOUNT",
+        message: `Amount "${String(rawAmount)}" could not be parsed as a numeric value.`,
+      });
+    }
+
+    const period = normalizePeriod(pick(raw, PERIOD_KEYS));
+    const department = coerceString(raw.department)?.trim() || undefined;
+
+    entries.push({
+      employeeId: employeeId ?? "",
+      walletAddress: walletAddress ?? "",
+      asset: asset ?? "",
+      amount: amount ?? "",
+      ...(period !== undefined ? { period } : {}),
+      ...(department !== undefined ? { department } : {}),
+      source: { index, raw },
+    });
+  });
+
+  return { entries, issues };
+}

--- a/packages/core/src/normalization/types.ts
+++ b/packages/core/src/normalization/types.ts
@@ -1,0 +1,111 @@
+/**
+ * Canonical payroll payload types.
+ *
+ * SDK consumers may supply payroll data in slightly different shapes
+ * (different key names, extra whitespace, comma-formatted amounts, mixed
+ * casing on addresses, etc). The normalizer in this module converts any of
+ * those shapes into one canonical form used internally by validation, proof
+ * preparation, and transaction building.
+ */
+
+/**
+ * Loosely-typed payroll entry as it may arrive from a consumer (CSV import,
+ * HR system export, hand-written object literal, ...). Field names are
+ * intentionally permissive — {@link normalizePayrollPayload} accepts several
+ * common aliases for each canonical field.
+ */
+export interface RawPayrollEntry {
+  employeeId?: unknown;
+  employee_id?: unknown;
+  id?: unknown;
+
+  recipient?: unknown;
+  walletAddress?: unknown;
+  wallet_address?: unknown;
+  wallet?: unknown;
+  address?: unknown;
+
+  asset?: unknown;
+  assetId?: unknown;
+  asset_id?: unknown;
+  token?: unknown;
+
+  period?: unknown;
+  periodId?: unknown;
+  period_id?: unknown;
+  payPeriod?: unknown;
+
+  amount?: unknown;
+  salaryAmount?: unknown;
+  salary_amount?: unknown;
+
+  department?: unknown;
+
+  [key: string]: unknown;
+}
+
+/** A raw payroll payload as supplied by an SDK consumer. */
+export interface RawPayrollPayload {
+  entries: RawPayrollEntry[];
+}
+
+/** Points back to the original input an entry was normalized from. */
+export interface PayrollEntrySource {
+  /** Position of this entry in the original `entries` array. */
+  index: number;
+  /** The untouched, original entry object. */
+  raw: RawPayrollEntry;
+}
+
+/**
+ * The canonical shape for a single payroll entry, used internally by the SDK
+ * for validation, proof preparation, and transaction building.
+ *
+ * Required fields (`employeeId`, `walletAddress`, `asset`, `amount`) are
+ * always present as strings — normalization never drops them. When the
+ * source data was missing or unusable, the field is set to `""` and a
+ * corresponding {@link NormalizationIssue} is recorded so validation can
+ * still surface a clear, positioned error instead of silently accepting bad
+ * data.
+ */
+export interface CanonicalPayrollEntry {
+  /** Trimmed employee identifier. */
+  employeeId: string;
+  /** Trimmed, uppercased wallet address (Stellar strkeys are uppercase). */
+  walletAddress: string;
+  /** Trimmed asset identifier; common XLM aliases collapse to `"native"`. */
+  asset: string;
+  /** Trimmed period identifier, if provided. */
+  period?: string;
+  /** Amount as a canonical numeric string (formatting artifacts stripped). */
+  amount: string;
+  /** Trimmed department label, if provided. */
+  department?: string;
+  /** Reference back to the original input, for error reporting. */
+  source: PayrollEntrySource;
+}
+
+/** Machine-readable reason a field could not be cleanly normalized. */
+export type NormalizationIssueCode = "MISSING" | "UNPARSEABLE_AMOUNT";
+
+/** A field on a specific entry that normalization could not fully resolve. */
+export interface NormalizationIssue {
+  /** Position of the affected entry in the original `entries` array. */
+  index: number;
+  /** Canonical field the issue applies to. */
+  field: "employeeId" | "walletAddress" | "asset" | "amount";
+  code: NormalizationIssueCode;
+  message: string;
+}
+
+/** Result of normalizing a raw payroll payload. */
+export interface NormalizedPayrollPayload {
+  /** Canonical entries, one per input entry, in the same order. */
+  entries: CanonicalPayrollEntry[];
+  /**
+   * Issues found while normalizing required fields. Empty when every entry
+   * had usable data for `employeeId`, `walletAddress`, `asset`, and `amount`.
+   * Downstream validation should treat entries referenced here as invalid.
+   */
+  issues: NormalizationIssue[];
+}

--- a/packages/core/tests/payroll-normalizer.test.ts
+++ b/packages/core/tests/payroll-normalizer.test.ts
@@ -1,0 +1,297 @@
+import {
+  normalizeAmount,
+  normalizeAssetId,
+  normalizeEmployeeId,
+  normalizePayrollPayload,
+  normalizePeriod,
+  normalizeWalletAddress,
+} from "../src/normalization/normalizer";
+import { RawPayrollEntry } from "../src/normalization/types";
+
+describe("field normalizers", () => {
+  describe("normalizeEmployeeId", () => {
+    it("trims surrounding whitespace", () => {
+      expect(normalizeEmployeeId("  E-100  ")).toBe("E-100");
+    });
+
+    it("coerces numbers to strings", () => {
+      expect(normalizeEmployeeId(42)).toBe("42");
+    });
+
+    it("returns undefined for missing/empty values", () => {
+      expect(normalizeEmployeeId(undefined)).toBeUndefined();
+      expect(normalizeEmployeeId(null)).toBeUndefined();
+      expect(normalizeEmployeeId("   ")).toBeUndefined();
+      expect(normalizeEmployeeId("")).toBeUndefined();
+    });
+  });
+
+  describe("normalizeWalletAddress", () => {
+    it("trims whitespace and uppercases", () => {
+      expect(normalizeWalletAddress("  gabc123def  ")).toBe("GABC123DEF");
+    });
+
+    it("leaves an already-uppercase address unchanged", () => {
+      expect(normalizeWalletAddress("GABC123DEF")).toBe("GABC123DEF");
+    });
+
+    it("returns undefined for missing/empty values", () => {
+      expect(normalizeWalletAddress(undefined)).toBeUndefined();
+      expect(normalizeWalletAddress("   ")).toBeUndefined();
+    });
+  });
+
+  describe("normalizeAssetId", () => {
+    it("collapses common XLM aliases (any casing) to 'native'", () => {
+      expect(normalizeAssetId("xlm")).toBe("native");
+      expect(normalizeAssetId("XLM")).toBe("native");
+      expect(normalizeAssetId("Lumens")).toBe("native");
+      expect(normalizeAssetId("  native  ")).toBe("native");
+    });
+
+    it("trims but preserves case for contract-id-style assets", () => {
+      expect(normalizeAssetId("  CABCDEF123  ")).toBe("CABCDEF123");
+    });
+
+    it("returns undefined for missing/empty values", () => {
+      expect(normalizeAssetId(undefined)).toBeUndefined();
+      expect(normalizeAssetId("")).toBeUndefined();
+    });
+  });
+
+  describe("normalizePeriod", () => {
+    it("trims whitespace", () => {
+      expect(normalizePeriod("  2025-Q2-P1  ")).toBe("2025-Q2-P1");
+    });
+
+    it("returns undefined when absent", () => {
+      expect(normalizePeriod(undefined)).toBeUndefined();
+    });
+  });
+
+  describe("normalizeAmount", () => {
+    it("stringifies bigint and number amounts", () => {
+      expect(normalizeAmount(1000n)).toBe("1000");
+      expect(normalizeAmount(1000.5)).toBe("1000.5");
+    });
+
+    it("strips thousands separators, currency symbols, and whitespace", () => {
+      expect(normalizeAmount("1,000.50")).toBe("1000.50");
+      expect(normalizeAmount("$1,000.50")).toBe("1000.50");
+      expect(normalizeAmount(" 1 000.50 ")).toBe("1000.50");
+      expect(normalizeAmount("€1,234")).toBe("1234");
+    });
+
+    it("drops a redundant leading plus sign", () => {
+      expect(normalizeAmount("+500")).toBe("500");
+    });
+
+    it("returns undefined for non-finite numbers and missing values", () => {
+      expect(normalizeAmount(NaN)).toBeUndefined();
+      expect(normalizeAmount(Infinity)).toBeUndefined();
+      expect(normalizeAmount(undefined)).toBeUndefined();
+      expect(normalizeAmount("   ")).toBeUndefined();
+    });
+
+    it("leaves an already-clean amount string unchanged", () => {
+      expect(normalizeAmount("1000.50")).toBe("1000.50");
+    });
+  });
+});
+
+describe("normalizePayrollPayload", () => {
+  it("normalizes whitespace, casing, and amount formatting across every field", () => {
+    const raw: RawPayrollEntry = {
+      employeeId: "  E-42  ",
+      recipient: "  gabc123def  ",
+      asset: " xlm ",
+      period: "  2025-Q2-P1  ",
+      amount: " 1,000.50 ",
+      department: "  Engineering  ",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(issues).toEqual([]);
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      employeeId: "E-42",
+      walletAddress: "GABC123DEF",
+      asset: "native",
+      period: "2025-Q2-P1",
+      amount: "1000.50",
+      department: "Engineering",
+    });
+  });
+
+  it("accepts common key aliases for each field", () => {
+    const raw: RawPayrollEntry = {
+      employee_id: "E-1",
+      wallet: "gdef456",
+      assetId: "USDC",
+      periodId: "2025-Q3-P1",
+      salaryAmount: "2500",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(issues).toEqual([]);
+    expect(entries[0]).toMatchObject({
+      employeeId: "E-1",
+      walletAddress: "GDEF456",
+      asset: "USDC",
+      period: "2025-Q3-P1",
+      amount: "2500",
+    });
+  });
+
+  it("leaves an already-normalized payload unchanged", () => {
+    const raw: RawPayrollEntry = {
+      employeeId: "E-1",
+      recipient: "GABC123DEF",
+      asset: "native",
+      period: "2025-Q2-P1",
+      amount: "1000.5000000",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(issues).toEqual([]);
+    expect(entries[0]).toMatchObject({
+      employeeId: "E-1",
+      walletAddress: "GABC123DEF",
+      asset: "native",
+      period: "2025-Q2-P1",
+      amount: "1000.5000000",
+    });
+  });
+
+  it("normalizes bigint and number amounts already in canonical form", () => {
+    const raw: RawPayrollEntry = {
+      employeeId: "E-1",
+      recipient: "GABC",
+      asset: "native",
+      amount: 1000n,
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(issues).toEqual([]);
+    expect(entries[0].amount).toBe("1000");
+  });
+
+  it("omits optional fields (period, department) when absent, without an issue", () => {
+    const raw: RawPayrollEntry = {
+      employeeId: "E-1",
+      recipient: "GABC",
+      asset: "native",
+      amount: "100",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(issues).toEqual([]);
+    expect(entries[0].period).toBeUndefined();
+    expect(entries[0].department).toBeUndefined();
+    expect("period" in entries[0]).toBe(false);
+  });
+
+  it("does not silently drop entries with missing required fields", () => {
+    const raw: RawPayrollEntry = {
+      period: "2025-Q2-P1",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(entries).toHaveLength(1);
+    expect(entries[0]).toMatchObject({
+      employeeId: "",
+      walletAddress: "",
+      asset: "",
+      amount: "",
+    });
+
+    const fields = issues.map((i) => i.field).sort();
+    expect(fields).toEqual(["amount", "asset", "employeeId", "walletAddress"]);
+    expect(issues.every((i) => i.code === "MISSING")).toBe(true);
+  });
+
+  it("flags unparseable amounts while preserving the cleaned value for review", () => {
+    const raw: RawPayrollEntry = {
+      employeeId: "E-1",
+      recipient: "GABC",
+      asset: "native",
+      amount: "not-a-number",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [raw] });
+
+    expect(entries[0].amount).toBe("not-a-number");
+    expect(issues).toEqual([
+      {
+        index: 0,
+        field: "amount",
+        code: "UNPARSEABLE_AMOUNT",
+        message: 'Amount "not-a-number" could not be parsed as a numeric value.',
+      },
+    ]);
+  });
+
+  it("preserves the original input and index on each entry's source", () => {
+    const rawA: RawPayrollEntry = {
+      employeeId: "E-1",
+      recipient: "GA",
+      asset: "native",
+      amount: "1",
+    };
+    const rawB: RawPayrollEntry = {
+      employeeId: "  ",
+      recipient: "GB",
+      asset: "native",
+      amount: "2",
+    };
+
+    const { entries, issues } = normalizePayrollPayload({ entries: [rawA, rawB] });
+
+    expect(entries[0].source).toEqual({ index: 0, raw: rawA });
+    expect(entries[1].source).toEqual({ index: 1, raw: rawB });
+
+    // A validation error for the second entry can point straight back at the
+    // original input via the recorded index and preserved raw object.
+    expect(issues[0].index).toBe(1);
+    expect(entries[issues[0].index].source.raw).toBe(rawB);
+  });
+
+  it("processes multiple entries independently, preserving order", () => {
+    const entriesInput: RawPayrollEntry[] = [
+      { employeeId: "E-1", recipient: "GA", asset: "native", amount: "100" },
+      { employeeId: "E-2", recipient: "GB", asset: "native", amount: "abc" },
+      { recipient: "GC", asset: "native", amount: "300" },
+    ];
+
+    const { entries, issues } = normalizePayrollPayload({ entries: entriesInput });
+
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.employeeId)).toEqual(["E-1", "E-2", ""]);
+    expect(issues).toEqual([
+      {
+        index: 1,
+        field: "amount",
+        code: "UNPARSEABLE_AMOUNT",
+        message: 'Amount "abc" could not be parsed as a numeric value.',
+      },
+      {
+        index: 2,
+        field: "employeeId",
+        code: "MISSING",
+        message: "Employee id is required but was missing or empty.",
+      },
+    ]);
+  });
+
+  it("returns empty entries and issues for an empty payload", () => {
+    const { entries, issues } = normalizePayrollPayload({ entries: [] });
+    expect(entries).toEqual([]);
+    expect(issues).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Implements a normalizer that converts user-provided payroll payloads into a canonical SDK format before validation, proof preparation, or transaction building.

- Defines the canonical payroll payload shape (`RawPayrollEntry`/`RawPayrollPayload` for loose input, `CanonicalPayrollEntry`/`NormalizedPayrollPayload` for the normalized output) in `packages/core/src/normalization/types.ts`.
- `normalizePayrollPayload()` normalizes employee ids, wallet addresses, asset identifiers, period values, and amount strings, accepting common key aliases (`recipient`/`walletAddress`/`wallet`/`address`, `employee_id`/`id`, `assetId`/`token`, `salaryAmount`, etc.), trimming whitespace, uppercasing wallet addresses, collapsing `xlm`/`lumens` aliases to `"native"`, and stripping currency symbols/commas/whitespace from amount strings.
- Normalization never throws or drops entries: required fields (`employeeId`, `walletAddress`, `asset`, `amount`) that are missing or unparseable are recorded as indexed `NormalizationIssue`s instead of being silently swallowed.
- Every canonical entry carries `source: { index, raw }`, preserving the original input so validation can still produce clear, positioned errors referencing the caller's original data.
- Exported from the package root (`@zk-payroll/core`).

## Test plan

- [x] `packages/core/tests/payroll-normalizer.test.ts` — 26 new tests covering whitespace, casing, amount formatting variations, key aliasing, missing required/optional fields, unparseable amounts, already-normalized (idempotent) payloads, and multi-entry ordering.
- [x] `npm run typecheck` (in `packages/core`) — passes.
- [x] `npm run lint` on the new files — clean.
- [x] Full existing test suite (933 tests) — passes.
- [x] Docs: added `docs/PAYLOAD_NORMALIZATION.md` and a README section/link.

Closes #171