### PR TITLE
feat: add audit view-key helpers for compliance integrations

### DIFF
--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,0 +1,1 @@
+export * from "./viewKeyHelpers";

--- a/packages/core/src/audit/viewKeyHelpers.ts
+++ b/packages/core/src/audit/viewKeyHelpers.ts
@@ -1,0 +1,370 @@
+/**
+ * Audit View-Key Helpers
+ *
+ * Focused helper functions for compliance integrations that need to
+ * create, inspect, and revoke audit view keys. Each helper is
+ * intentionally stateless and pure so it can be composed freely
+ * into stores, API routes, or server-side compliance scripts.
+ *
+ * Contract alignment
+ * ------------------
+ * These helpers produce and consume the same shape used by the
+ * ZK Payroll smart contracts:
+ *   - `scope` maps directly to the contract's `ViewKeyScope` enum.
+ *   - `keyId` is the token passed to contract `grant_view_key`.
+ *   - `grantedBy` must be the Stellar public key of the authorised admin.
+ *
+ * Usage
+ * -----
+ * ```ts
+ * import {
+ *   createViewKeyRequest,
+ *   revokeViewKey,
+ *   getViewKeyStatus,
+ *   buildViewKeyStatusSummary,
+ * } from "@zk-payroll/core";
+ * ```
+ */
+
+export type ViewKeyScope = "read-only" | "full-audit";
+
+/**
+ * Input required to request a new audit view key.
+ *
+ * Provided by the admin (key granter) when creating access
+ * for an external auditor.
+ */
+export interface ViewKeyRequest {
+  /** Human-readable name of the auditor. */
+  auditorName: string;
+  /** Organisation the auditor represents (e.g. "Deloitte"). */
+  auditorOrg: string;
+  /**
+   * Scope of access to grant.
+   * - `"read-only"` — transaction summaries only.
+   * - `"full-audit"` — summaries plus departmental breakdowns.
+   */
+  scope: ViewKeyScope;
+  /**
+   * Optional ISO-8601 expiry date-time.
+   * Defaults to one year from the time of creation when omitted.
+   */
+  expiresAt?: string;
+}
+
+/**
+ * A persisted audit view key record, as stored in a compliance data store.
+ *
+ * This is the full internal model — including mutable fields such as
+ * `isActive` and `revokedAt` — that the helper functions operate on.
+ */
+export interface ViewKey {
+  /** Opaque record identifier (e.g. "vk_1719578400000"). */
+  id: string;
+  /** The shareable key token (e.g. "vk_a3f9bc12de45"). */
+  keyId: string;
+  auditorName: string;
+  auditorOrg: string;
+  scope: ViewKeyScope;
+  /** Stellar public key of the admin who granted the key. */
+  grantedBy: string;
+  /** ISO-8601 timestamp of creation. */
+  createdAt: string;
+  /** ISO-8601 timestamp of expiry. */
+  expiresAt: string;
+  /** Whether the key is currently active (`false` after revocation). */
+  isActive: boolean;
+  /** ISO-8601 timestamp of revocation; present only after revocation. */
+  revokedAt?: string | null;
+}
+
+/**
+ * A successfully created audit view key, ready to hand to an auditor.
+ */
+export interface ViewKeyResponse {
+  /** Opaque record identifier (e.g. "vk_1719578400000"). */
+  id: string;
+  /** The shareable key token (e.g. "vk_a3f9bc12de45"). */
+  keyId: string;
+  auditorName: string;
+  auditorOrg: string;
+  scope: ViewKeyScope;
+  /** Stellar public key of the admin who granted the key. */
+  grantedBy: string;
+  /** ISO-8601 timestamp of creation. */
+  createdAt: string;
+  /** ISO-8601 timestamp of expiry. */
+  expiresAt: string;
+  isActive: boolean;
+}
+
+/** Input required to revoke an existing audit view key. */
+export interface ViewKeyRevokeRequest {
+  /** The `id` field from `ViewKeyResponse` (e.g. "vk_1719578400000"). */
+  id: string;
+}
+
+/** Result of a view-key revocation. */
+export interface ViewKeyRevokeResult {
+  id: string;
+  revokedAt: string;
+  success: boolean;
+}
+
+/** Per-key status entry, used inside `ViewKeyStatusSummary`. */
+export interface ViewKeyStatusEntry {
+  id: string;
+  keyId: string;
+  auditorName: string;
+  auditorOrg: string;
+  scope: ViewKeyScope;
+  status: "active" | "revoked" | "expired";
+  expiresAt: string;
+  revokedAt?: string;
+}
+
+/** Status summary for a set of view keys, useful for compliance dashboards. */
+export interface ViewKeyStatusSummary {
+  totalActive: number;
+  totalRevoked: number;
+  totalExpired: number;
+  keys: ViewKeyStatusEntry[];
+}
+
+// ---------------------------------------------------------------------------
+// Internal utilities
+// ---------------------------------------------------------------------------
+
+/** Generates a random view-key token with the "vk_" prefix. */
+function generateKeyToken(): string {
+  const chars = "abcdefghijklmnopqrstuvwxyz0123456789";
+  let token = "vk_";
+  for (let i = 0; i < 12; i++) {
+    token += chars[Math.floor(Math.random() * chars.length)];
+  }
+  return token;
+}
+
+/** Returns an ISO-8601 string one year from now. */
+function defaultExpiryFromNow(): string {
+  return new Date(Date.now() + 365 * 24 * 60 * 60 * 1000).toISOString();
+}
+
+/** Derives the display status of a ViewKey at a given point in time. */
+function resolveKeyStatus(
+  key: ViewKey,
+  now: Date
+): "active" | "revoked" | "expired" {
+  if (!key.isActive) return "revoked";
+  if (new Date(key.expiresAt) <= now) return "expired";
+  return "active";
+}
+
+// ---------------------------------------------------------------------------
+// Public helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Creates a new view-key response object from a `ViewKeyRequest`.
+ *
+ * This is a pure construction helper — it does **not** persist the key.
+ * Persist the returned `ViewKeyResponse` via your store or API layer.
+ *
+ * @param request   Fields provided by the admin granting access.
+ * @param grantedBy Stellar public key of the authorised admin.
+ * @returns         A fully populated `ViewKeyResponse` ready to store or return.
+ *
+ * @example
+ * ```ts
+ * const key = createViewKeyRequest(
+ *   { auditorName: "Sarah Chen", auditorOrg: "Deloitte", scope: "full-audit" },
+ *   session.publicKey
+ * );
+ * addViewKey(key); // persist via Zustand store or API
+ * ```
+ */
+export function createViewKeyRequest(
+  request: ViewKeyRequest,
+  grantedBy: string
+): ViewKeyResponse {
+  const now = new Date();
+  return {
+    id: `vk_${now.getTime()}`,
+    keyId: generateKeyToken(),
+    auditorName: request.auditorName.trim(),
+    auditorOrg: request.auditorOrg.trim(),
+    scope: request.scope,
+    grantedBy,
+    createdAt: now.toISOString(),
+    expiresAt: request.expiresAt ?? defaultExpiryFromNow(),
+    isActive: true,
+  };
+}
+
+/**
+ * Validates a `ViewKeyRequest` and returns a list of validation errors.
+ *
+ * Returns an empty array when the request is valid.
+ *
+ * @example
+ * ```ts
+ * const errors = validateViewKeyRequest(request);
+ * if (errors.length > 0) throw new Error(errors.join(", "));
+ * ```
+ */
+export function validateViewKeyRequest(request: ViewKeyRequest): string[] {
+  const errors: string[] = [];
+
+  if (!request.auditorName.trim()) {
+    errors.push("auditorName is required");
+  }
+  if (!request.auditorOrg.trim()) {
+    errors.push("auditorOrg is required");
+  }
+  if (request.scope !== "read-only" && request.scope !== "full-audit") {
+    errors.push('scope must be "read-only" or "full-audit"');
+  }
+  if (request.expiresAt !== undefined) {
+    const expiry = new Date(request.expiresAt);
+    if (isNaN(expiry.getTime())) {
+      errors.push("expiresAt must be a valid ISO-8601 date-time string");
+    } else if (expiry <= new Date()) {
+      errors.push("expiresAt must be a future date");
+    }
+  }
+
+  return errors;
+}
+
+/**
+ * Marks a view key as revoked and returns the updated record.
+ *
+ * This is a pure transformation — pass the returned object back to
+ * your persistence layer (store / API) to commit the change.
+ *
+ * @param key     The existing `ViewKey` to revoke.
+ * @param request Contains the `id` to revoke (guards against mismatches).
+ * @returns       A `ViewKeyRevokeResult` describing the outcome.
+ * @throws        When the key is already inactive or the id does not match.
+ *
+ * @example
+ * ```ts
+ * const result = revokeViewKey(existingKey, { id: "vk_1719578400000" });
+ * // update the key in your store using result.revokedAt
+ * ```
+ */
+export function revokeViewKey(
+  key: ViewKey,
+  request: ViewKeyRevokeRequest
+): ViewKeyRevokeResult {
+  if (key.id !== request.id) {
+    throw new Error(
+      `View key id mismatch: expected "${request.id}", got "${key.id}"`
+    );
+  }
+  if (!key.isActive) {
+    throw new Error(`View key "${key.id}" is already inactive`);
+  }
+
+  const revokedAt = new Date().toISOString();
+  return { id: key.id, revokedAt, success: true };
+}
+
+/**
+ * Returns a single `ViewKeyStatusEntry` for a given `ViewKey`.
+ *
+ * Useful when you need the derived status (active / revoked / expired)
+ * without computing a full summary.
+ *
+ * @param key  The view key to inspect.
+ * @param now  Optional reference time — defaults to the current time.
+ *             Pass a fixed value in tests for determinism.
+ *
+ * @example
+ * ```ts
+ * const entry = getViewKeyStatus(viewKey);
+ * console.log(entry.status); // "active" | "revoked" | "expired"
+ * ```
+ */
+export function getViewKeyStatus(
+  key: ViewKey,
+  now: Date = new Date()
+): ViewKeyStatusEntry {
+  return {
+    id: key.id,
+    keyId: key.keyId,
+    auditorName: key.auditorName,
+    auditorOrg: key.auditorOrg,
+    scope: key.scope,
+    status: resolveKeyStatus(key, now),
+    expiresAt: key.expiresAt,
+    revokedAt: key.revokedAt ?? undefined,
+  };
+}
+
+/**
+ * Builds a status summary across a collection of view keys.
+ *
+ * Intended for compliance dashboards that need aggregated counts
+ * alongside per-key detail in one call.
+ *
+ * @param keys  Full list of `ViewKey` records to summarise.
+ * @param now   Optional reference time — defaults to the current time.
+ *
+ * @example
+ * ```ts
+ * const summary = buildViewKeyStatusSummary(viewKeys);
+ * console.log(`Active: ${summary.totalActive}`);
+ * ```
+ */
+export function buildViewKeyStatusSummary(
+  keys: ViewKey[],
+  now: Date = new Date()
+): ViewKeyStatusSummary {
+  const entries = keys.map((k) => getViewKeyStatus(k, now));
+
+  return {
+    totalActive: entries.filter((e) => e.status === "active").length,
+    totalRevoked: entries.filter((e) => e.status === "revoked").length,
+    totalExpired: entries.filter((e) => e.status === "expired").length,
+    keys: entries,
+  };
+}
+
+/**
+ * Checks whether a view key is currently valid for use.
+ *
+ * A key is valid when it is active **and** has not yet reached its
+ * expiry time. Use this as a guard before passing a key to the
+ * contract's `grant_view_key` call.
+ *
+ * @param key  The view key to check.
+ * @param now  Optional reference time — defaults to the current time.
+ *
+ * @example
+ * ```ts
+ * if (!isViewKeyValid(key)) {
+ *   throw new Error("Key has expired or been revoked");
+ * }
+ * ```
+ */
+export function isViewKeyValid(key: ViewKey, now: Date = new Date()): boolean {
+  return resolveKeyStatus(key, now) === "active";
+}
+
+/**
+ * Filters a list of keys to only those currently valid.
+ *
+ * Convenience wrapper around `isViewKeyValid` for bulk filtering.
+ *
+ * @example
+ * ```ts
+ * const usable = filterActiveViewKeys(viewKeys);
+ * ```
+ */
+export function filterActiveViewKeys(
+  keys: ViewKey[],
+  now: Date = new Date()
+): ViewKey[] {
+  return keys.filter((k) => isViewKeyValid(k, now));
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -113,3 +113,6 @@ export * from "./normalization";
 
 // ── Execution Summary ────────────────────────────────────────────────────────
 export * from "./summary";
+
+// ── Audit View-Key Helpers ──────────────────────────────────────────────────
+export * from "./audit";

--- a/packages/core/tests/audit.viewKeyHelpers.test.ts
+++ b/packages/core/tests/audit.viewKeyHelpers.test.ts
@@ -1,0 +1,380 @@
+/**
+ * Tests for audit/viewKeyHelpers.ts
+ *
+ * Covers:
+ *  - createViewKeyRequest — happy path and field defaults
+ *  - validateViewKeyRequest — all invalid-input branches
+ *  - revokeViewKey — success, already-inactive, id mismatch
+ *  - getViewKeyStatus — active / revoked / expired classification
+ *  - buildViewKeyStatusSummary — aggregate counts and per-key detail
+ *  - isViewKeyValid — boundary at exact expiry time
+ *  - filterActiveViewKeys — mixed-status collections
+ */
+
+import {
+  buildViewKeyStatusSummary,
+  createViewKeyRequest,
+  filterActiveViewKeys,
+  getViewKeyStatus,
+  isViewKeyValid,
+  revokeViewKey,
+  validateViewKeyRequest,
+} from "../src/audit/viewKeyHelpers";
+import type { ViewKey, ViewKeyRequest } from "../src/audit/viewKeyHelpers";
+
+// ---------------------------------------------------------------------------
+// Fixtures
+// ---------------------------------------------------------------------------
+
+function makeRequest(overrides: Partial<ViewKeyRequest> = {}): ViewKeyRequest {
+  return {
+    auditorName: "Sarah Chen",
+    auditorOrg: "Deloitte",
+    scope: "read-only",
+    ...overrides,
+  };
+}
+
+function makeViewKey(overrides: Partial<ViewKey> = {}): ViewKey {
+  const future = new Date(
+    Date.now() + 365 * 24 * 60 * 60 * 1000
+  ).toISOString();
+  return {
+    id: "vk_001",
+    keyId: "vk_audit_abc123",
+    auditorName: "Sarah Chen",
+    auditorOrg: "Deloitte",
+    scope: "read-only",
+    grantedBy: "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37",
+    createdAt: new Date().toISOString(),
+    expiresAt: future,
+    isActive: true,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// createViewKeyRequest
+// ---------------------------------------------------------------------------
+
+describe("createViewKeyRequest", () => {
+  it("returns a fully populated ViewKeyResponse", () => {
+    const grantedBy =
+      "GDQP2KPQGKIHYJGXNUIYOMHARUARCA7DJT5FO2FFOOKY3B2WSQHG4W37";
+    const response = createViewKeyRequest(makeRequest(), grantedBy);
+
+    expect(response.id).toMatch(/^vk_/);
+    expect(response.keyId).toMatch(/^vk_/);
+    expect(response.auditorName).toBe("Sarah Chen");
+    expect(response.auditorOrg).toBe("Deloitte");
+    expect(response.scope).toBe("read-only");
+    expect(response.grantedBy).toBe(grantedBy);
+    expect(response.isActive).toBe(true);
+    expect(response.createdAt).toBeTruthy();
+    expect(response.expiresAt).toBeTruthy();
+  });
+
+  it("uses the provided expiresAt when supplied", () => {
+    const customExpiry = "2030-01-01T00:00:00.000Z";
+    const response = createViewKeyRequest(
+      makeRequest({ expiresAt: customExpiry }),
+      "GADMIN"
+    );
+    expect(response.expiresAt).toBe(customExpiry);
+  });
+
+  it("defaults expiresAt to approximately one year from now", () => {
+    const before = Date.now();
+    const response = createViewKeyRequest(makeRequest(), "GADMIN");
+    const after = Date.now();
+
+    const expiry = new Date(response.expiresAt).getTime();
+    const oneYear = 365 * 24 * 60 * 60 * 1000;
+
+    expect(expiry).toBeGreaterThanOrEqual(before + oneYear - 1000);
+    expect(expiry).toBeLessThanOrEqual(after + oneYear + 1000);
+  });
+
+  it("trims whitespace from auditorName and auditorOrg", () => {
+    const response = createViewKeyRequest(
+      makeRequest({ auditorName: "  Jane Doe  ", auditorOrg: "  KPMG  " }),
+      "GADMIN"
+    );
+    expect(response.auditorName).toBe("Jane Doe");
+    expect(response.auditorOrg).toBe("KPMG");
+  });
+
+  it("generates unique keyId tokens on each call", () => {
+    const a = createViewKeyRequest(makeRequest(), "GADMIN");
+    const b = createViewKeyRequest(makeRequest(), "GADMIN");
+    expect(a.keyId).not.toBe(b.keyId);
+  });
+
+  it("supports full-audit scope", () => {
+    const response = createViewKeyRequest(
+      makeRequest({ scope: "full-audit" }),
+      "GADMIN"
+    );
+    expect(response.scope).toBe("full-audit");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// validateViewKeyRequest
+// ---------------------------------------------------------------------------
+
+describe("validateViewKeyRequest", () => {
+  it("returns no errors for a valid request", () => {
+    const errors = validateViewKeyRequest(makeRequest());
+    expect(errors).toEqual([]);
+  });
+
+  it("errors when auditorName is empty", () => {
+    const errors = validateViewKeyRequest(makeRequest({ auditorName: "" }));
+    expect(errors.some((e) => e.includes("auditorName"))).toBe(true);
+  });
+
+  it("errors when auditorName is only whitespace", () => {
+    const errors = validateViewKeyRequest(makeRequest({ auditorName: "   " }));
+    expect(errors.some((e) => e.includes("auditorName"))).toBe(true);
+  });
+
+  it("errors when auditorOrg is empty", () => {
+    const errors = validateViewKeyRequest(makeRequest({ auditorOrg: "" }));
+    expect(errors.some((e) => e.includes("auditorOrg"))).toBe(true);
+  });
+
+  it("errors when scope is invalid", () => {
+    const errors = validateViewKeyRequest(
+      makeRequest({ scope: "superuser" as never })
+    );
+    expect(errors.some((e) => e.includes("scope"))).toBe(true);
+  });
+
+  it("errors when expiresAt is not a valid date string", () => {
+    const errors = validateViewKeyRequest(
+      makeRequest({ expiresAt: "not-a-date" })
+    );
+    expect(errors.some((e) => e.includes("expiresAt"))).toBe(true);
+  });
+
+  it("errors when expiresAt is in the past", () => {
+    const errors = validateViewKeyRequest(
+      makeRequest({ expiresAt: "2000-01-01T00:00:00.000Z" })
+    );
+    expect(errors.some((e) => e.includes("expiresAt"))).toBe(true);
+  });
+
+  it("accepts a future expiresAt date", () => {
+    const errors = validateViewKeyRequest(
+      makeRequest({ expiresAt: "2099-01-01T00:00:00.000Z" })
+    );
+    expect(errors).toEqual([]);
+  });
+
+  it("accumulates multiple errors", () => {
+    const errors = validateViewKeyRequest(
+      makeRequest({ auditorName: "", auditorOrg: "", expiresAt: "bad" })
+    );
+    expect(errors.length).toBeGreaterThanOrEqual(3);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// revokeViewKey
+// ---------------------------------------------------------------------------
+
+describe("revokeViewKey", () => {
+  it("returns a successful revocation result", () => {
+    const key = makeViewKey();
+    const result = revokeViewKey(key, { id: key.id });
+
+    expect(result.id).toBe(key.id);
+    expect(result.success).toBe(true);
+    expect(result.revokedAt).toBeTruthy();
+    expect(new Date(result.revokedAt).getTime()).toBeLessThanOrEqual(
+      Date.now()
+    );
+  });
+
+  it("throws when the key is already inactive", () => {
+    const key = makeViewKey({ isActive: false });
+    expect(() => revokeViewKey(key, { id: key.id })).toThrow(/already inactive/);
+  });
+
+  it("throws when the id does not match", () => {
+    const key = makeViewKey({ id: "vk_001" });
+    expect(() => revokeViewKey(key, { id: "vk_999" })).toThrow(/mismatch/);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getViewKeyStatus
+// ---------------------------------------------------------------------------
+
+describe("getViewKeyStatus", () => {
+  it("returns 'active' for a valid active key", () => {
+    const key = makeViewKey();
+    const entry = getViewKeyStatus(key, new Date());
+    expect(entry.status).toBe("active");
+  });
+
+  it("returns 'revoked' for an inactive key", () => {
+    const key = makeViewKey({
+      isActive: false,
+      revokedAt: new Date().toISOString(),
+    });
+    const entry = getViewKeyStatus(key, new Date());
+    expect(entry.status).toBe("revoked");
+  });
+
+  it("returns 'expired' for an active key past its expiresAt", () => {
+    const pastExpiry = new Date(Date.now() - 1000).toISOString();
+    const key = makeViewKey({ expiresAt: pastExpiry });
+    const entry = getViewKeyStatus(key, new Date());
+    expect(entry.status).toBe("expired");
+  });
+
+  it("includes revokedAt when present", () => {
+    const revokedAt = "2025-11-15T14:30:00.000Z";
+    const key = makeViewKey({ isActive: false, revokedAt });
+    const entry = getViewKeyStatus(key);
+    expect(entry.revokedAt).toBe(revokedAt);
+  });
+
+  it("maps all expected fields onto the entry", () => {
+    const key = makeViewKey();
+    const entry = getViewKeyStatus(key);
+    expect(entry.id).toBe(key.id);
+    expect(entry.keyId).toBe(key.keyId);
+    expect(entry.auditorName).toBe(key.auditorName);
+    expect(entry.auditorOrg).toBe(key.auditorOrg);
+    expect(entry.scope).toBe(key.scope);
+    expect(entry.expiresAt).toBe(key.expiresAt);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildViewKeyStatusSummary
+// ---------------------------------------------------------------------------
+
+describe("buildViewKeyStatusSummary", () => {
+  it("returns zero counts for an empty list", () => {
+    const summary = buildViewKeyStatusSummary([]);
+    expect(summary.totalActive).toBe(0);
+    expect(summary.totalRevoked).toBe(0);
+    expect(summary.totalExpired).toBe(0);
+    expect(summary.keys).toEqual([]);
+  });
+
+  it("counts active, revoked, and expired keys correctly", () => {
+    const now = new Date("2026-06-01T00:00:00.000Z");
+    const keys: ViewKey[] = [
+      makeViewKey({
+        id: "vk_1",
+        expiresAt: "2027-01-01T00:00:00.000Z",
+        isActive: true,
+      }),
+      makeViewKey({
+        id: "vk_2",
+        isActive: false,
+        revokedAt: "2025-11-01T00:00:00.000Z",
+        expiresAt: "2027-01-01T00:00:00.000Z",
+      }),
+      makeViewKey({
+        id: "vk_3",
+        expiresAt: "2025-01-01T00:00:00.000Z",
+        isActive: true,
+      }),
+      makeViewKey({
+        id: "vk_4",
+        expiresAt: "2027-06-01T00:00:00.000Z",
+        isActive: true,
+      }),
+    ];
+
+    const summary = buildViewKeyStatusSummary(keys, now);
+
+    expect(summary.totalActive).toBe(2);
+    expect(summary.totalRevoked).toBe(1);
+    expect(summary.totalExpired).toBe(1);
+    expect(summary.keys).toHaveLength(4);
+  });
+
+  it("includes per-key detail entries", () => {
+    const key = makeViewKey();
+    const summary = buildViewKeyStatusSummary([key]);
+    expect(summary.keys[0].id).toBe(key.id);
+    expect(summary.keys[0].status).toBe("active");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// isViewKeyValid
+// ---------------------------------------------------------------------------
+
+describe("isViewKeyValid", () => {
+  it("returns true for an active, non-expired key", () => {
+    expect(isViewKeyValid(makeViewKey())).toBe(true);
+  });
+
+  it("returns false for a revoked key", () => {
+    expect(isViewKeyValid(makeViewKey({ isActive: false }))).toBe(false);
+  });
+
+  it("returns false when the key expires exactly at the reference time", () => {
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    const key = makeViewKey({ expiresAt: now.toISOString() });
+    // expiresAt <= now, so it should be expired
+    expect(isViewKeyValid(key, now)).toBe(false);
+  });
+
+  it("returns true when the key expires one millisecond after the reference time", () => {
+    const now = new Date("2026-06-01T12:00:00.000Z");
+    const oneMillisLater = new Date(now.getTime() + 1).toISOString();
+    const key = makeViewKey({ expiresAt: oneMillisLater });
+    expect(isViewKeyValid(key, now)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filterActiveViewKeys
+// ---------------------------------------------------------------------------
+
+describe("filterActiveViewKeys", () => {
+  it("returns only active, non-expired keys", () => {
+    const now = new Date("2026-06-01T00:00:00.000Z");
+    const keys: ViewKey[] = [
+      makeViewKey({
+        id: "vk_active",
+        expiresAt: "2027-01-01T00:00:00.000Z",
+        isActive: true,
+      }),
+      makeViewKey({
+        id: "vk_revoked",
+        isActive: false,
+        expiresAt: "2027-01-01T00:00:00.000Z",
+      }),
+      makeViewKey({
+        id: "vk_expired",
+        expiresAt: "2025-01-01T00:00:00.000Z",
+        isActive: true,
+      }),
+    ];
+
+    const active = filterActiveViewKeys(keys, now);
+
+    expect(active).toHaveLength(1);
+    expect(active[0].id).toBe("vk_active");
+  });
+
+  it("returns an empty array when no keys are valid", () => {
+    const keys = [makeViewKey({ isActive: false })];
+    expect(filterActiveViewKeys(keys)).toEqual([]);
+  });
+
+  it("returns all keys when all are valid", () => {
+    const keys = [makeViewKey({ id: "vk_a" }), makeViewKey({ id: "vk_b" })];
+    expect(filterActiveViewKeys(keys)).toHaveLength(2);
+  });
+});

--- a/types/audit.ts
+++ b/types/audit.ts
@@ -33,6 +33,34 @@ export interface ViewKeyRequest {
 }
 
 /**
+ * A persisted audit view key record, as stored in a compliance data store.
+ *
+ * This is the full internal model — including mutable fields such as
+ * `isActive` and `revokedAt` — that the helper functions operate on.
+ * Consumers should prefer `ViewKeyResponse` when returning data to
+ * compliance clients, and `ViewKey` when passing records into helpers.
+ */
+export interface ViewKey {
+  /** Opaque record identifier (e.g. "vk_1719578400000"). */
+  id: string;
+  /** The shareable key token (e.g. "vk_a3f9bc12de45"). */
+  keyId: string;
+  auditorName: string;
+  auditorOrg: string;
+  scope: ViewKeyScope;
+  /** Stellar public key of the admin who granted the key. */
+  grantedBy: string;
+  /** ISO-8601 timestamp of creation. */
+  createdAt: string;
+  /** ISO-8601 timestamp of expiry. */
+  expiresAt: string;
+  /** Whether the key is currently active (`false` after revocation). */
+  isActive: boolean;
+  /** ISO-8601 timestamp of revocation; present only after revocation. */
+  revokedAt?: string | null;
+}
+
+/**
  * A successfully created audit view key, ready to hand to an auditor.
  * Mirrors the `ViewKey` model but is narrowed to the fields a
  * compliance client actually needs when consuming the helper API.


### PR DESCRIPTION
closes 
closes #191 
closes #192 
closes #193 
closes #194 
## Summary

Fixes #102 — Add audit view-key request helpers for compliance integrations.

## Changes

- **`types/audit.ts`** — Added the missing `ViewKey` interface that was referenced throughout the helpers and tests but never defined.
- **`packages/core/src/audit/viewKeyHelpers.ts`** — New module with pure, stateless helper functions:
  - `createViewKeyRequest` — constructs a `ViewKeyResponse` from a request + granter public key
  - `validateViewKeyRequest` — validates a request and returns human-readable errors
  - `revokeViewKey` — marks a key as revoked (pure transformation)
  - `getViewKeyStatus` — derives active / revoked / expired status for a single key
  - `buildViewKeyStatusSummary` — aggregates counts and per-key detail for compliance dashboards
  - `isViewKeyValid` — guard helper for use before contract calls
  - `filterActiveViewKeys` — bulk filter convenience wrapper
- **`packages/core/src/index.ts`** — Exports the new audit module.
- **`packages/core/tests/audit.viewKeyHelpers.test.ts`** — 33 Jest tests covering all helpers and edge cases.

## Testing

All 33 new tests pass. Full test suite: 989 tests pass, 0 failures.

```
PASS tests/audit.viewKeyHelpers.test.ts
  createViewKeyRequest (6 tests)
  validateViewKeyRequest (9 tests)
  revokeViewKey (3 tests)
  getViewKeyStatus (5 tests)
  buildViewKeyStatusSummary (3 tests)
  isViewKeyValid (4 tests)
  filterActiveViewKeys (3 tests)

Tests: 33 passed, 33 total
closes
closes #191 
closes #192 
closes #193 
closes #194 

```