### PR TITLE
Add artifact hash verification and transaction inspection/classification

### DIFF
--- a/packages/core/src/classification/TransactionFailureClassifier.ts
+++ b/packages/core/src/classification/TransactionFailureClassifier.ts
@@ -1,0 +1,360 @@
+import {
+  ContractExecutionError,
+  NetworkError,
+  ContractErrorCode,
+  classifyContractErrorCode,
+  classifyTimeoutFailure,
+  TimeoutFailureState,
+} from "../errors";
+import type { ContractErrorCodeType } from "../errors";
+import type { FailureCategory, TransactionFailureClassification } from "./types";
+
+/**
+ * Maps a Soroban RPC {@link SendTransactionResponse} status to a failure
+ * classification.
+ *
+ * Call this when {@link rpc.Server.sendTransaction} returns a non-PENDING
+ * status (i.e. `"ERROR"` or `"TRY_AGAIN_LATER"`).
+ *
+ * @param status  The `status` field from the send response.
+ * @returns       A classification with category and recovery hint.
+ */
+export function classifySendResponse(status: string): TransactionFailureClassification {
+  switch (status) {
+    case "TRY_AGAIN_LATER":
+      return {
+        category: "retryable",
+        code: "SUBMISSION_QUEUE_FULL",
+        message:
+          "Soroban RPC rejected the submission because its pending " +
+          "transaction queue is full or it is temporarily overloaded.",
+        canRetry: true,
+        recoveryHint:
+          "Wait a few seconds and re-submit the same transaction. " +
+          "The queue pressure is usually transient.",
+        rpcStatus: "TRY_AGAIN_LATER",
+      };
+
+    case "ERROR":
+      return {
+        category: "terminal",
+        code: "TRANSACTION_ERROR",
+        message:
+          "The network rejected the transaction at submission time — " +
+          "the transaction is invalid or incoherent.",
+        canRetry: false,
+        recoveryHint:
+          "Inspect the `errorResult` XDR from the send response. " +
+          "Common causes: insufficient fee, bad signatures, or " +
+          "account sequence mismatch. Re-submitting the same envelope " +
+          "will fail again.",
+        rpcStatus: "ERROR",
+      };
+
+    case "DUPLICATE":
+      return {
+        category: "terminal",
+        code: "DUPLICATE_TRANSACTION",
+        message: "A transaction with the same hash was already submitted " + "to the network.",
+        canRetry: false,
+        recoveryHint:
+          "No action needed — the transaction is already in-flight. " +
+          "Poll for its result using the hash.",
+        rpcStatus: "DUPLICATE",
+      };
+
+    default:
+      return {
+        category: "unknown",
+        code: "UNKNOWN_SEND_STATUS",
+        message: `Unrecognized sendTransaction status: "${status}".`,
+        canRetry: false,
+        recoveryHint: "Check the Soroban RPC version and SDK compatibility.",
+        rpcStatus: status,
+      };
+  }
+}
+
+/**
+ * Maps a Soroban RPC {@link GetTransactionResponse} status to a failure
+ * classification.
+ *
+ * Call this when the transaction ended in a non-SUCCESS terminal state
+ * (i.e. `"FAILED"` or `"NOT_FOUND"` after the expected ledger window).
+ *
+ * @param status    The `status` field from the get-transaction response.
+ * @param isExpired Optional. Set to `true` when `NOT_FOUND` is received
+ *                  after the ledger close time has passed, indicating the
+ *                  transaction expired rather than still being in-flight.
+ * @returns         A classification with category and recovery hint.
+ */
+export function classifyGetResponse(
+  status: string,
+  isExpired?: boolean
+): TransactionFailureClassification {
+  switch (status) {
+    case "FAILED":
+      return {
+        category: "terminal",
+        code: "CONTRACT_REVERT",
+        message:
+          "The transaction was included in a ledger but the contract " +
+          "call reverted. The state changes were rolled back.",
+        canRetry: false,
+        recoveryHint:
+          "This is deterministic — the same inputs will always " +
+          "revert. Inspect the `resultXdr` or `diagnosticEventsXdr` " +
+          "from the get-transaction response for the exact error. " +
+          "Fix the contract inputs or the contract itself before retrying.",
+        rpcStatus: "FAILED",
+      };
+
+    case "NOT_FOUND":
+      if (isExpired) {
+        return {
+          category: "expired",
+          code: "TRANSACTION_NOT_FOUND",
+          message:
+            "The transaction was submitted but not found in any " +
+            "ledger before the lookup window expired.",
+          canRetry: false,
+          recoveryHint:
+            "The transaction may have been dropped or never " +
+            "propagated. Build a **new** transaction (with an " +
+            "updated sequence number) and re-submit.",
+          rpcStatus: "NOT_FOUND",
+        };
+      }
+      return {
+        category: "retryable",
+        code: "TRANSACTION_NOT_FOUND",
+        message:
+          "The transaction has not yet appeared in any ledger. " +
+          "It may still be in the submission queue or pending " +
+          "validation.",
+        canRetry: true,
+        recoveryHint:
+          "Keep polling — the transaction may still be " +
+          "in-flight. If `NOT_FOUND` persists beyond the " +
+          "expected ledger close window, classify as expired.",
+        rpcStatus: "NOT_FOUND",
+      };
+
+    default:
+      return {
+        category: "unknown",
+        code: "UNKNOWN_GET_STATUS",
+        message: `Unrecognized getTransaction status: "${status}".`,
+        canRetry: false,
+        recoveryHint: "Check the Soroban RPC version and SDK compatibility.",
+        rpcStatus: status,
+      };
+  }
+}
+
+/**
+ * Classifies any error thrown during a transaction lifecycle (simulation,
+ * submission, or polling) into one of four categories.
+ *
+ * Accepts:
+ * - {@link ContractExecutionError} — uses the stable `code` field.
+ * - {@link NetworkError} — uses HTTP status code heuristics.
+ * - Plain {@link Error} — uses message-pattern matching.
+ * - Any other thrown value — falls back to `"unknown"`.
+ *
+ * @example
+ * ```typescript
+ * import { classifyTransactionFailure } from "@zk-payroll/core";
+ *
+ * try {
+ *   await payroll.processPayment(params);
+ * } catch (err) {
+ *   const result = classifyTransactionFailure(err);
+ *
+ *   if (result.category === "retryable") {
+ *     await delay(1000);
+ *     await payroll.processPayment(params);
+ *   } else if (result.category === "expired") {
+ *     // Build new transaction with fresh sequence
+ *     await payroll.processPayment(params);
+ *   } else {
+ *     reportError(result);
+ *   }
+ * }
+ * ```
+ *
+ * @param error - The error (or thrown value) to classify.
+ * @returns A structured classification with category and recovery hint.
+ */
+export function classifyTransactionFailure(error: unknown): TransactionFailureClassification {
+  if (error instanceof ContractExecutionError) {
+    return classifyContractExecutionError(error);
+  }
+
+  if (error instanceof NetworkError) {
+    return classifyNetworkError(error);
+  }
+
+  if (error instanceof Error) {
+    return classifyGenericError(error);
+  }
+
+  return {
+    category: "unknown",
+    code: "UNKNOWN_ERROR",
+    message: `Non-Error thrown value: ${String(error)}`,
+    canRetry: false,
+    recoveryHint:
+      "Cannot determine the failure cause. Inspect logs and " + "re-submit with caution.",
+  };
+}
+
+// ── Private helpers ────────────────────────────────────────────────────────
+
+function classifyContractExecutionError(
+  err: ContractExecutionError
+): TransactionFailureClassification {
+  const state = classifyContractErrorCode(err.code as ContractErrorCodeType);
+
+  return {
+    category: normalizeState(state),
+    code: err.code,
+    message: err.message,
+    canRetry: state === TimeoutFailureState.RETRYABLE,
+    recoveryHint: recoveryHintForCode(err.code, state as FailureCategory),
+    details: { ...err.context },
+  };
+}
+
+function classifyNetworkError(err: NetworkError): TransactionFailureClassification {
+  const statusCode = err.statusCode;
+  const isRetryable = statusCode === undefined || statusCode >= 500 || statusCode === 429;
+
+  let hint: string;
+  if (statusCode === undefined) {
+    hint =
+      "Network error without an HTTP status code — likely a transient " +
+      "connection issue. Wait and retry.";
+  } else if (statusCode >= 500) {
+    hint =
+      `Server error (HTTP ${statusCode}) — the RPC endpoint may be ` +
+      `overloaded or temporarily unavailable. Retry with backoff.`;
+  } else if (statusCode === 429) {
+    hint =
+      `Rate limited (HTTP 429) — wait for the advised retry ` + `interval before re-submitting.`;
+  } else {
+    hint =
+      `Client error (HTTP ${statusCode}) — the request was ` +
+      `malformed or forbidden. Re-submitting the same request will ` +
+      `fail again.`;
+  }
+
+  const category: FailureCategory = isRetryable ? "retryable" : "terminal";
+
+  return {
+    category,
+    code: err.code,
+    message: err.message,
+    canRetry: isRetryable,
+    recoveryHint: hint,
+    details: { statusCode },
+  };
+}
+
+function classifyGenericError(err: Error): TransactionFailureClassification {
+  const state = classifyTimeoutFailure(err);
+
+  return {
+    category: normalizeState(state),
+    code: "UNKNOWN_ERROR",
+    message: err.message,
+    canRetry: state === TimeoutFailureState.RETRYABLE,
+    recoveryHint: recoveryHintForCategory(normalizeState(state)),
+  };
+}
+
+function normalizeState(state: string): FailureCategory {
+  switch (state) {
+    case TimeoutFailureState.RETRYABLE:
+      return "retryable";
+    case TimeoutFailureState.TERMINAL:
+      return "terminal";
+    case TimeoutFailureState.EXPIRED:
+      return "expired";
+    default:
+      return "unknown";
+  }
+}
+
+function recoveryHintForCode(code: string, category: FailureCategory): string {
+  switch (code) {
+    case ContractErrorCode.TRANSACTION_TIMEOUT:
+      return (
+        `The polling loop exhausted its maximum number of attempts. ` +
+        `The transaction may still be in-flight or may have been dropped. ` +
+        `Check the transaction status manually via the Soroban RPC using ` +
+        `the returned transaction hash.`
+      );
+    case ContractErrorCode.SIMULATION_FAILED:
+      return (
+        `The Soroban simulation rejected the contract invocation. ` +
+        `This is deterministic — the same inputs will always fail ` +
+        `simulation. Review the contract arguments for correctness.`
+      );
+    case ContractErrorCode.CONTRACT_REVERT:
+      return (
+        `The contract execution reverted on-chain. Inspect the ` +
+        `diagnostic events or the transaction result XDR for the ` +
+        `revert reason. The same call with identical inputs will ` +
+        `always revert.`
+      );
+    case ContractErrorCode.TRANSACTION_SUBMISSION_FAILED:
+      return (
+        `The network rejected the transaction at submission. ` +
+        `This is often transient — check the RPC endpoint health ` +
+        `and retry with backoff.`
+      );
+    case ContractErrorCode.INSUFFICIENT_FEE:
+      return (
+        `The transaction fee was too low for the current network ` +
+        `conditions. Increase the fee and build a new transaction ` +
+        `(sequence number must be updated) before re-submitting.`
+      );
+    case ContractErrorCode.RPC_TIMEOUT:
+      return (
+        `The Soroban RPC request timed out. This is usually ` +
+        `transient — retry the same operation with a longer timeout.`
+      );
+    case ContractErrorCode.INVALID_RESPONSE:
+      return (
+        `The Soroban RPC returned a malformed response. ` +
+        `This is usually transient — retry the same operation.`
+      );
+    default:
+      return recoveryHintForCategory(category);
+  }
+}
+
+function recoveryHintForCategory(category: FailureCategory): string {
+  switch (category) {
+    case "retryable":
+      return "Wait and re-submit the same transaction. The failure " + "appears to be transient.";
+    case "terminal":
+      return (
+        "The same transaction will always fail with these inputs. " +
+        "Inspect the error details, fix the root cause, and build a " +
+        "new transaction."
+      );
+    case "expired":
+      return (
+        "Build a **new** transaction with an updated sequence " +
+        "number and/or time-bounds before re-submitting. The " +
+        "original envelope can no longer be used."
+      );
+    case "unknown":
+      return (
+        "Cannot determine the failure cause. Inspect logs, " +
+        "verify the Soroban RPC endpoint, and re-submit with caution."
+      );
+  }
+}

--- a/packages/core/src/classification/index.ts
+++ b/packages/core/src/classification/index.ts
@@ -1,0 +1,6 @@
+export {
+  classifyTransactionFailure,
+  classifySendResponse,
+  classifyGetResponse,
+} from "./TransactionFailureClassifier";
+export type { FailureCategory, TransactionFailureClassification } from "./types";

--- a/packages/core/src/classification/types.ts
+++ b/packages/core/src/classification/types.ts
@@ -1,0 +1,42 @@
+/**
+ * Four-state classification for a transaction failure.
+ *
+ * - **retryable** — The failure is transient (network blip, RPC timeout,
+ *   submission queue full).  Re-submitting the **same** transaction has a
+ *   reasonable chance of succeeding.
+ * - **terminal** — The failure is deterministic (contract revert,
+ *   simulation error, invalid arguments).  Re-submitting the **same**
+ *   transaction **will** fail again.
+ * - **expired** — The transaction's time-window or sequence-number window
+ *   has passed.  A **new** transaction (with an updated sequence number
+ *   and/or time-bounds) might succeed.
+ * - **unknown** — The root cause cannot be determined from available
+ *   information.  Proceed with caution.
+ */
+export type FailureCategory = "retryable" | "terminal" | "expired" | "unknown";
+
+/**
+ * Structured result from classifying a transaction failure.
+ */
+export interface TransactionFailureClassification {
+  /** One of the four failure categories. */
+  category: FailureCategory;
+  /** Stable machine-readable error code (e.g. `"TRANSACTION_TIMEOUT"`). */
+  code: string;
+  /** Human-readable description of what happened. */
+  message: string;
+  /** Whether re-submitting the same transaction is likely to help. */
+  canRetry: boolean;
+  /** Actionable guidance for the caller. */
+  recoveryHint: string;
+  /**
+   * The underlying Soroban RPC transaction status that produced this
+   * failure, when applicable (e.g. `"TRY_AGAIN_LATER"`, `"NOT_FOUND"`).
+   */
+  rpcStatus?: string;
+  /**
+   * Extra debugging context (error codes, HTTP statuses, etc.).
+   * Never contains secret or private-input data.
+   */
+  details?: Record<string, unknown>;
+}

--- a/packages/core/src/crypto/ArtifactErrors.ts
+++ b/packages/core/src/crypto/ArtifactErrors.ts
@@ -22,6 +22,8 @@ export const ArtifactErrorCode = {
   ARTIFACT_CORRUPT: "ARTIFACT_CORRUPT",
   /** An HTTP request for a remote artifact failed. */
   ARTIFACT_FETCH_FAILED: "ARTIFACT_FETCH_FAILED",
+  /** The artifact content does not match the expected SHA-256 hash. */
+  ARTIFACT_HASH_MISMATCH: "ARTIFACT_HASH_MISMATCH",
 } as const;
 
 export type ArtifactErrorCode = (typeof ArtifactErrorCode)[keyof typeof ArtifactErrorCode];
@@ -94,5 +96,28 @@ export class ArtifactFetchError extends ZkPayrollError {
       { url, artifactType }
     );
     this.name = "ArtifactFetchError";
+  }
+}
+
+/**
+ * Thrown when a circuit artifact's SHA-256 hash does not match the expected value.
+ * This prevents proof generation or transaction assembly with tampered or
+ * incorrect artifacts.
+ */
+export class ArtifactHashMismatchError extends ZkPayrollError {
+  constructor(
+    artifactPath: string,
+    artifactType: "wasm" | "zkey",
+    expected: string,
+    actual: string
+  ) {
+    super(
+      `SHA-256 hash mismatch for ${artifactType} artifact at "${artifactPath}": ` +
+        `expected ${expected} but got ${actual}. ` +
+        `The artifact may be corrupted, tampered with, or from an unexpected version.`,
+      ArtifactErrorCode.ARTIFACT_HASH_MISMATCH,
+      { path: artifactPath, artifactType, expected, actual }
+    );
+    this.name = "ArtifactHashMismatchError";
   }
 }

--- a/packages/core/src/crypto/IArtifactResolver.ts
+++ b/packages/core/src/crypto/IArtifactResolver.ts
@@ -26,8 +26,8 @@
  * ```
  */
 export type ArtifactSource =
-  | { type: "remote"; url: string }
-  | { type: "local"; path: string };
+  | { type: "remote"; url: string; expectedSha256Hash?: string }
+  | { type: "local"; path: string; expectedSha256Hash?: string };
 
 /**
  * The resolved binary content of a pair of circuit artifacts,

--- a/packages/core/src/crypto/IProofGenerator.ts
+++ b/packages/core/src/crypto/IProofGenerator.ts
@@ -93,6 +93,16 @@ export interface ProofGeneratorConfig {
    * ```
    */
   zkeySource?: import("./IArtifactResolver").ArtifactSource;
+  /**
+   * Expected SHA-256 hex hash of the .wasm artifact.
+   * When set, the hash is verified before proof generation begins.
+   */
+  expectedWasmHash?: string;
+  /**
+   * Expected SHA-256 hex hash of the .zkey artifact.
+   * When set, the hash is verified before proof generation begins.
+   */
+  expectedZkeyHash?: string;
   /** Optional cache TTL in seconds for downloaded artifacts */
   artifactCacheTTL?: number;
   /**

--- a/packages/core/src/crypto/LocalArtifactResolver.ts
+++ b/packages/core/src/crypto/LocalArtifactResolver.ts
@@ -47,7 +47,9 @@ import {
   ArtifactNotFoundError,
   ArtifactAccessError,
   ArtifactCorruptError,
+  ArtifactHashMismatchError,
 } from "./ArtifactErrors";
+import { sha256Digest } from "./hashUtils";
 import { SdkLogger } from "../logging/SdkLogger";
 
 /**
@@ -58,6 +60,18 @@ export interface LocalArtifactResolverConfig {
   wasmPath: string;
   /** Absolute or relative path to the proving key .zkey file. */
   zkeyPath: string;
+  /**
+   * Expected SHA-256 hex digest of the .wasm file.
+   * When set, the resolver verifies the file hash before returning,
+   * throwing {@link ArtifactHashMismatchError} on mismatch.
+   */
+  expectedWasmHash?: string;
+  /**
+   * Expected SHA-256 hex digest of the .zkey file.
+   * When set, the resolver verifies the file hash before returning,
+   * throwing {@link ArtifactHashMismatchError} on mismatch.
+   */
+  expectedZkeyHash?: string;
 }
 
 /**
@@ -80,6 +94,8 @@ export interface LocalArtifactResolverConfig {
 export class LocalArtifactResolver implements IArtifactResolver {
   private readonly wasmPath: string;
   private readonly zkeyPath: string;
+  private readonly expectedWasmHash?: string;
+  private readonly expectedZkeyHash?: string;
 
   constructor(
     config: LocalArtifactResolverConfig,
@@ -87,6 +103,8 @@ export class LocalArtifactResolver implements IArtifactResolver {
   ) {
     this.wasmPath = path.resolve(config.wasmPath);
     this.zkeyPath = path.resolve(config.zkeyPath);
+    this.expectedWasmHash = config.expectedWasmHash;
+    this.expectedZkeyHash = config.expectedZkeyHash;
   }
 
   /**
@@ -109,6 +127,12 @@ export class LocalArtifactResolver implements IArtifactResolver {
       this.loadFile(this.zkeyPath, "zkey"),
     ]);
 
+    // Verify SHA-256 hashes if expected values were provided
+    await Promise.all([
+      this.verifyHash(wasm, this.wasmPath, "wasm", this.expectedWasmHash),
+      this.verifyHash(zkey, this.zkeyPath, "zkey", this.expectedZkeyHash),
+    ]);
+
     this.logger?.info("artifact_load_complete", { source: "local" });
 
     // Copy into a plain ArrayBuffer to satisfy the ResolvedArtifacts type
@@ -125,10 +149,7 @@ export class LocalArtifactResolver implements IArtifactResolver {
   /**
    * Loads and validates a single artifact file.
    */
-  private async loadFile(
-    filePath: string,
-    artifactType: "wasm" | "zkey"
-  ): Promise<Uint8Array> {
+  private async loadFile(filePath: string, artifactType: "wasm" | "zkey"): Promise<Uint8Array> {
     // 1. Validate extension
     const ext = path.extname(filePath).toLowerCase();
     const expectedExt = `.${artifactType}`;
@@ -156,11 +177,7 @@ export class LocalArtifactResolver implements IArtifactResolver {
         );
       }
       // Re-throw unexpected errors
-      throw new ArtifactAccessError(
-        filePath,
-        artifactType,
-        nodeError.message
-      );
+      throw new ArtifactAccessError(filePath, artifactType, nodeError.message);
     }
 
     // 3. Read file
@@ -176,5 +193,31 @@ export class LocalArtifactResolver implements IArtifactResolver {
     }
 
     return new Uint8Array(buffer);
+  }
+
+  /**
+   * Verifies the SHA-256 hash of loaded content against an expected value.
+   * Throws ArtifactHashMismatchError on mismatch. No-op if expectedHash is undefined.
+   */
+  private async verifyHash(
+    content: Uint8Array,
+    artifactPath: string,
+    artifactType: "wasm" | "zkey",
+    expectedHash?: string
+  ): Promise<void> {
+    if (!expectedHash) {
+      return;
+    }
+
+    const actualHash = await sha256Digest(content);
+
+    if (actualHash !== expectedHash.toLowerCase()) {
+      throw new ArtifactHashMismatchError(artifactPath, artifactType, expectedHash, actualHash);
+    }
+
+    this.logger?.info("artifact_hash_verified", {
+      type: artifactType,
+      path: artifactPath,
+    });
   }
 }

--- a/packages/core/src/crypto/RemoteArtifactResolver.ts
+++ b/packages/core/src/crypto/RemoteArtifactResolver.ts
@@ -13,7 +13,8 @@
 
 import axios from "axios";
 import { IArtifactResolver, ResolvedArtifacts } from "./IArtifactResolver";
-import { ArtifactFetchError } from "./ArtifactErrors";
+import { ArtifactFetchError, ArtifactHashMismatchError } from "./ArtifactErrors";
+import { sha256Digest } from "./hashUtils";
 import { SdkLogger } from "../logging/SdkLogger";
 
 /**
@@ -28,6 +29,18 @@ export interface RemoteArtifactResolverConfig {
   wasmTimeoutMs?: number;
   /** Timeout in milliseconds for the .zkey download. @default 60000 */
   zkeyTimeoutMs?: number;
+  /**
+   * Expected SHA-256 hex digest of the .wasm file.
+   * When set, the resolver verifies the hash before returning,
+   * throwing {@link ArtifactHashMismatchError} on mismatch.
+   */
+  expectedWasmHash?: string;
+  /**
+   * Expected SHA-256 hex digest of the .zkey file.
+   * When set, the resolver verifies the hash before returning,
+   * throwing {@link ArtifactHashMismatchError} on mismatch.
+   */
+  expectedZkeyHash?: string;
 }
 
 /**
@@ -44,32 +57,36 @@ export interface RemoteArtifactResolverConfig {
  * ```
  */
 export class RemoteArtifactResolver implements IArtifactResolver {
+  private readonly config: RemoteArtifactResolverConfig;
+
   constructor(
-    private readonly config: RemoteArtifactResolverConfig,
+    config: RemoteArtifactResolverConfig,
     private readonly logger?: SdkLogger
-  ) {}
+  ) {
+    this.config = { ...config };
+  }
 
   /**
    * Fetches both circuit artifact files over HTTP.
    *
    * @returns Resolved wasm and zkey binary content.
    * @throws {ArtifactFetchError} If either HTTP request fails.
+   * @throws {ArtifactHashMismatchError} If an expected hash is set and the content doesn't match.
    */
   async resolve(): Promise<ResolvedArtifacts> {
     const [wasm, zkey] = await Promise.all([
-      this.fetchArtifact(
-        this.config.wasmUrl,
-        "wasm",
-        this.config.wasmTimeoutMs ?? 30_000
-      ),
-      this.fetchArtifact(
-        this.config.zkeyUrl,
-        "zkey",
-        this.config.zkeyTimeoutMs ?? 60_000
-      ),
+      this.fetchArtifact(this.config.wasmUrl, "wasm", this.config.wasmTimeoutMs ?? 30_000),
+      this.fetchArtifact(this.config.zkeyUrl, "zkey", this.config.zkeyTimeoutMs ?? 60_000),
     ]);
 
-    return { wasm, zkey: new Uint8Array(zkey) };
+    // Verify SHA-256 hashes if expected values were provided
+    const zkeyBytes = new Uint8Array(zkey);
+    await Promise.all([
+      this.verifyHash(wasm, this.config.wasmUrl, "wasm", this.config.expectedWasmHash),
+      this.verifyHash(zkeyBytes, this.config.zkeyUrl, "zkey", this.config.expectedZkeyHash),
+    ]);
+
+    return { wasm, zkey: zkeyBytes };
   }
 
   /**
@@ -97,5 +114,31 @@ export class RemoteArtifactResolver implements IArtifactResolver {
         error instanceof Error ? error.message : String(error)
       );
     }
+  }
+
+  /**
+   * Verifies the SHA-256 hash of fetched content against an expected value.
+   * No-op if expectedHash is undefined.
+   */
+  private async verifyHash(
+    content: Uint8Array | ArrayBuffer,
+    url: string,
+    artifactType: "wasm" | "zkey",
+    expectedHash?: string
+  ): Promise<void> {
+    if (!expectedHash) {
+      return;
+    }
+
+    const actualHash = await sha256Digest(content);
+
+    if (actualHash !== expectedHash.toLowerCase()) {
+      throw new ArtifactHashMismatchError(url, artifactType, expectedHash, actualHash);
+    }
+
+    this.logger?.info("artifact_hash_verified", {
+      type: artifactType,
+      url,
+    });
   }
 }

--- a/packages/core/src/crypto/SnarkjsProofGenerator.ts
+++ b/packages/core/src/crypto/SnarkjsProofGenerator.ts
@@ -10,6 +10,8 @@ import {
   PreloadStatus,
   witnessKey,
 } from "./IProofGenerator";
+import { ArtifactHashMismatchError } from "./ArtifactErrors";
+import { sha256Digest } from "./hashUtils";
 import { SdkLogger } from "../logging/SdkLogger";
 import { Semaphore } from "../core/concurrency";
 import { IdempotencyRegistry } from "../core/idempotency";
@@ -45,6 +47,8 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
   private preloadStatus: PreloadStatus = { wasmLoaded: false, zkeyLoaded: false };
 
   private readonly config: ProofGeneratorConfig;
+  private readonly expectedWasmHash?: string;
+  private readonly expectedZkeyHash?: string;
   private readonly dedup: IdempotencyRegistry<ProofPayload>;
   private readonly semaphore: Semaphore;
 
@@ -56,10 +60,14 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
     validateProofConfig(config);
 
     const wasmUrl = config.wasmSource
-      ? (config.wasmSource.type === "local" ? config.wasmSource.path : config.wasmSource.url)
+      ? config.wasmSource.type === "local"
+        ? config.wasmSource.path
+        : config.wasmSource.url
       : config.wasmUrl!;
     const zkeyUrl = config.zkeySource
-      ? (config.zkeySource.type === "local" ? config.zkeySource.path : config.zkeySource.url)
+      ? config.zkeySource.type === "local"
+        ? config.zkeySource.path
+        : config.zkeySource.url
       : config.zkeyUrl!;
 
     this.config = {
@@ -67,6 +75,8 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
       wasmUrl,
       zkeyUrl,
     };
+    this.expectedWasmHash = config.expectedWasmHash;
+    this.expectedZkeyHash = config.expectedZkeyHash;
     const permits = config.maxConcurrency ?? DEFAULT_MAX_CONCURRENCY;
     this.semaphore = new Semaphore(permits);
     this.dedup = new IdempotencyRegistry<ProofPayload>(0);
@@ -92,9 +102,7 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
         error: error instanceof Error ? error.message : String(error),
       });
       throw new PayrollError(
-        `Proof generation failed: ${
-          error instanceof Error ? error.message : String(error)
-        }`,
+        `Proof generation failed: ${error instanceof Error ? error.message : String(error)}`,
         500
       );
     }
@@ -201,10 +209,15 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
         this.wasmCache = ab;
       }
 
+      await this.verifyHash(this.wasmCache, this.config.wasmUrl, "wasm", this.expectedWasmHash);
+
       this.preloadStatus = { ...this.preloadStatus, wasmLoaded: true };
       this.logger?.info("artifact_fetch_complete", { type: "wasm" });
       return this.wasmCache;
     } catch (error) {
+      if (error instanceof ArtifactHashMismatchError) {
+        throw error;
+      }
       throw new PayrollError(
         `Failed to fetch wasm artifact from ${this.config.wasmUrl}: ${
           error instanceof Error ? error.message : String(error)
@@ -247,10 +260,15 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
         this.zkeyCache = new Uint8Array(buffer);
       }
 
+      await this.verifyHash(this.zkeyCache, this.config.zkeyUrl, "zkey", this.expectedZkeyHash);
+
       this.preloadStatus = { ...this.preloadStatus, zkeyLoaded: true };
       this.logger?.info("artifact_fetch_complete", { type: "zkey" });
       return this.zkeyCache;
     } catch (error) {
+      if (error instanceof ArtifactHashMismatchError) {
+        throw error;
+      }
       throw new PayrollError(
         `Failed to fetch zkey artifact from ${this.config.zkeyUrl}: ${
           error instanceof Error ? error.message : String(error)
@@ -258,6 +276,25 @@ export class SnarkjsProofGenerator implements IPreloadableProofGenerator {
         500
       );
     }
+  }
+
+  private async verifyHash(
+    content: Uint8Array | ArrayBuffer,
+    source: string,
+    artifactType: "wasm" | "zkey",
+    expectedHash?: string
+  ): Promise<void> {
+    if (!expectedHash) {
+      return;
+    }
+
+    const actualHash = await sha256Digest(content);
+
+    if (actualHash !== expectedHash.toLowerCase()) {
+      throw new ArtifactHashMismatchError(source, artifactType, expectedHash, actualHash);
+    }
+
+    this.logger?.info("artifact_hash_verified", { type: artifactType, source });
   }
 
   private formatProofPayload(

--- a/packages/core/src/crypto/hashUtils.ts
+++ b/packages/core/src/crypto/hashUtils.ts
@@ -1,0 +1,19 @@
+/**
+ * Computes the SHA-256 hex digest of the given binary data.
+ *
+ * Uses Web Crypto API (`crypto.subtle`) which is available in:
+ *   - Node.js 18+ (globalThis.crypto)
+ *   - All modern browsers
+ *
+ * @param data - The binary data to hash.
+ * @returns Hex-encoded SHA-256 digest (lowercase, 64 characters).
+ */
+export async function sha256Digest(data: Uint8Array | ArrayBuffer): Promise<string> {
+  const hashBuffer = await crypto.subtle.digest("SHA-256", data as ArrayBuffer);
+  const hashArray = new Uint8Array(hashBuffer);
+  let hex = "";
+  for (let i = 0; i < hashArray.length; i++) {
+    hex += hashArray[i].toString(16).padStart(2, "0");
+  }
+  return hex;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -119,3 +119,9 @@ export * from "./audit";
 
 // ── Webhook Verification ────────────────────────────────────────────────────
 export * from "./webhooks";
+
+// ── Transaction Inspection ──────────────────────────────────────────────────
+export * from "./inspector";
+
+// ── Transaction Failure Classification ──────────────────────────────────────
+export * from "./classification";

--- a/packages/core/src/inspector/TransactionInspector.ts
+++ b/packages/core/src/inspector/TransactionInspector.ts
@@ -1,0 +1,262 @@
+import {
+  Transaction,
+  MemoNone,
+  MemoText,
+  MemoHash,
+  MemoReturn,
+  MemoID,
+  Operation,
+  StrKey,
+  xdr,
+} from "@stellar/stellar-sdk";
+import type { TransactionSummary, OperationSummary } from "./types";
+
+/**
+ * Safely inspects a Stellar transaction envelope and returns a summary
+ * of its operations, network, fees, and signers — without leaking
+ * private contract-call arguments or other sensitive inputs.
+ *
+ * Use this helper before signing to let users review what a transaction
+ * will do before they approve it in their wallet.
+ *
+ * @example
+ * ```typescript
+ * import { inspectTransaction } from "@zk-payroll/core";
+ *
+ * const summary = await inspectTransaction(tx);
+ * console.log(summary.operations);
+ * // → [{ type: "invokeHostFunction", functionName: "private_pay", … }]
+ * ```
+ *
+ * @param tx - The Stellar Transaction envelope to inspect.
+ * @returns A safe, serializable summary of the transaction's intent.
+ */
+export function inspectTransaction(tx: Transaction): TransactionSummary {
+  const hashBuf = tx.hash();
+  const ops = tx.operations.map(describeOperation);
+
+  let hasSorobanAuth = false;
+  let totalAuthCount = 0;
+
+  for (const op of tx.operations) {
+    if (op.type === "invokeHostFunction") {
+      const invokeOp = op as Operation.InvokeHostFunction;
+      const authCount = invokeOp.auth?.length ?? 0;
+      if (authCount > 0) {
+        hasSorobanAuth = true;
+        totalAuthCount += authCount;
+      }
+    }
+  }
+
+  const sigHints = tx.signatures.map((sig) => Buffer.from(sig.hint()).toString("hex"));
+
+  let memoValue: string | undefined;
+  let memoType: string | undefined;
+
+  if (tx.memo && tx.memo.type !== MemoNone) {
+    memoType = tx.memo.type;
+    if (tx.memo.value !== null && tx.memo.value !== undefined) {
+      if (tx.memo.type === MemoText) {
+        memoValue = tx.memo.value as string;
+      } else if (tx.memo.type === MemoHash || tx.memo.type === MemoReturn) {
+        memoValue = Buffer.from(tx.memo.value as Buffer).toString("hex");
+      } else if (tx.memo.type === MemoID) {
+        memoValue = String(tx.memo.value);
+      }
+    }
+  }
+
+  return {
+    source: tx.source,
+    fee: tx.fee,
+    network: tx.networkPassphrase,
+    sequence: tx.sequence,
+    hash: hashBuf.toString("hex"),
+    signatureCount: tx.signatures.length,
+    signerHints: sigHints,
+    operations: ops,
+    memo: memoValue,
+    memoType,
+    hasSorobanAuth,
+    sorobanAuthCount: hasSorobanAuth ? totalAuthCount : undefined,
+    timeBounds: tx.timeBounds
+      ? {
+          minTime: tx.timeBounds.minTime,
+          maxTime: tx.timeBounds.maxTime,
+        }
+      : undefined,
+  };
+}
+
+/**
+ * Describes a single high-level Operation safely.
+ * Argument values are never included.
+ */
+function describeOperation(op: Operation): OperationSummary {
+  const base: OperationSummary = {
+    type: op.type,
+    description: op.type,
+  };
+
+  switch (op.type) {
+    case "invokeHostFunction": {
+      const invokeOp = op as Operation.InvokeHostFunction;
+      return describeHostFunction(invokeOp);
+    }
+
+    case "extendFootprintTtl": {
+      const extOp = op as Operation.ExtendFootprintTTL;
+      return {
+        ...base,
+        description: `Extend TTL by ${extOp.extendTo} ledgers`,
+      };
+    }
+
+    case "restoreFootprint": {
+      return {
+        ...base,
+        description: "Restore footprint (archival entries)",
+      };
+    }
+
+    case "payment": {
+      const payOp = op as Operation.Payment;
+      return {
+        ...base,
+        description: `Send ${payOp.amount} ${payOp.asset.getCode()} to ${truncateAddress(payOp.destination)}`,
+      };
+    }
+
+    case "createAccount": {
+      const caOp = op as Operation.CreateAccount;
+      return {
+        ...base,
+        description: `Create account ${truncateAddress(caOp.destination)} with ${caOp.startingBalance} XLM`,
+      };
+    }
+
+    case "accountMerge": {
+      const amOp = op as Operation.AccountMerge;
+      return {
+        ...base,
+        description: `Merge account into ${truncateAddress(amOp.destination)}`,
+      };
+    }
+
+    case "manageData": {
+      const mdOp = op as Operation.ManageData;
+      return {
+        ...base,
+        description: `Set data entry "${mdOp.name}"`,
+      };
+    }
+
+    case "bumpSequence": {
+      const bsOp = op as Operation.BumpSequence;
+      return {
+        ...base,
+        description: `Bump sequence to ${bsOp.bumpTo}`,
+      };
+    }
+
+    default: {
+      return base;
+    }
+  }
+}
+
+/**
+ * Describes a host-function operation (invoke, create, or upload).
+ */
+function describeHostFunction(op: Operation.InvokeHostFunction): OperationSummary {
+  const func = op.func;
+  const typeName = func.switch().name;
+  const authCount = op.auth?.length ?? 0;
+
+  switch (typeName) {
+    case "hostFunctionTypeInvokeContract": {
+      const args = func.invokeContract();
+      const functionName = extractFunctionName(args.functionName());
+      const contractId = extractContractId(args.contractAddress());
+      const argCount = args.args().length;
+
+      return {
+        type: "invokeHostFunction",
+        contractId,
+        functionName,
+        argumentCount: argCount,
+        authCount,
+        description: `Invoke ${functionName ?? "?"} on ${truncateAddress(contractId ?? "?")} (${argCount} arg${argCount !== 1 ? "s" : ""})`,
+      };
+    }
+
+    case "hostFunctionTypeCreateContract":
+    case "hostFunctionTypeCreateContractV2": {
+      let description = "Create contract";
+      if (typeName === "hostFunctionTypeCreateContractV2") {
+        description = "Create contract v2";
+      }
+      return {
+        type: "invokeHostFunction",
+        authCount,
+        description,
+      };
+    }
+
+    case "hostFunctionTypeUploadContractWasm": {
+      return {
+        type: "invokeHostFunction",
+        authCount,
+        description: "Upload contract WASM",
+      };
+    }
+
+    default: {
+      return {
+        type: "invokeHostFunction",
+        description: `Invoke host function (${typeName})`,
+      };
+    }
+  }
+}
+
+function extractFunctionName(raw: string | Buffer): string | undefined {
+  if (typeof raw === "string" && raw.length > 0) {
+    return raw;
+  }
+  if (typeof raw === "object" && raw !== null) {
+    try {
+      const s = Buffer.isBuffer(raw) ? raw.toString("utf8") : String(raw);
+      return s.length > 0 ? s : undefined;
+    } catch {
+      return undefined;
+    }
+  }
+  return undefined;
+}
+
+function extractContractId(scAddress: xdr.ScAddress): string | undefined {
+  try {
+    if (scAddress.switch().name !== "scAddressTypeContract") {
+      return undefined;
+    }
+    const contractId = scAddress.contractId();
+    if (contractId === null || contractId === undefined) {
+      return undefined;
+    }
+    const raw = Buffer.isBuffer(contractId)
+      ? contractId
+      : Buffer.from(contractId as unknown as Uint8Array);
+    return StrKey.encodeContract(raw);
+  } catch {
+    return undefined;
+  }
+}
+
+function truncateAddress(addr: string | undefined): string | undefined {
+  if (!addr || addr.length < 12) {
+    return addr;
+  }
+  return `${addr.slice(0, 6)}...${addr.slice(-4)}`;
+}

--- a/packages/core/src/inspector/index.ts
+++ b/packages/core/src/inspector/index.ts
@@ -1,0 +1,2 @@
+export { inspectTransaction } from "./TransactionInspector";
+export type { TransactionSummary, OperationSummary } from "./types";

--- a/packages/core/src/inspector/types.ts
+++ b/packages/core/src/inspector/types.ts
@@ -1,0 +1,73 @@
+/**
+ * Result of inspecting a Stellar transaction envelope.
+ *
+ * All fields are safe to expose — no private inputs (ScVal arguments,
+ * contract function arguments, witness data, etc.) are included.
+ */
+export interface TransactionSummary {
+  /** Source account (G... public key). */
+  source: string;
+  /** Transaction fee in stroops. */
+  fee: string;
+  /** Network passphrase (e.g. "Test SDF Network ; September 2015"). */
+  network: string;
+  /** Source account sequence number. */
+  sequence: string;
+  /** SHA-256 hash of the transaction envelope (hex-encoded). */
+  hash: string;
+  /** Number of signatures attached to the envelope. */
+  signatureCount: number;
+  /** Hex-encoded signature hints (last 4 bytes of each signer's public key). */
+  signerHints: string[];
+  /** Human-readable summaries of each operation (no private arguments leaked). */
+  operations: OperationSummary[];
+  /** Memo text (if the memo type is `MemoText`, `MemoHash`, or `MemoReturn`). */
+  memo?: string;
+  /** Memo type constant. */
+  memoType?: string;
+  /** Whether any operation includes Soroban authorization entries. */
+  hasSorobanAuth: boolean;
+  /** Total number of Soroban authorization entries across all operations. */
+  sorobanAuthCount?: number;
+  /** Optional time-bounds set on the transaction. */
+  timeBounds?: {
+    minTime?: string;
+    maxTime?: string;
+  };
+}
+
+/**
+ * Safe summary of a single transaction operation.
+ *
+ * Argument values are NEVER included — only their count is reported,
+ * so private inputs cannot leak through the inspection result.
+ */
+export interface OperationSummary {
+  /**
+   * Operation type name, as returned by the Stellar SDK
+   * (e.g. "invokeHostFunction", "payment", "createAccount").
+   */
+  type: string;
+  /**
+   * Contract ID (C... address) for invokeHostFunction operations
+   * that call a contract. Omitted for non-contract operations.
+   */
+  contractId?: string;
+  /**
+   * Contract function name for invokeHostFunction operations.
+   */
+  functionName?: string;
+  /**
+   * Number of function arguments. Count is reported so callers can
+   * verify the operation shape without leaking argument values.
+   */
+  argumentCount?: number;
+  /**
+   * Number of Soroban authorization entries attached to this operation.
+   */
+  authCount?: number;
+  /**
+   * Human-readable one-line description of what this operation does.
+   */
+  description: string;
+}


### PR DESCRIPTION
- ArtifactHashMismatchError with SHA-256 verification in both local and remote resolvers, plus SnarkjsProofGenerator download paths
- inspectTransaction helper for safe transaction envelope inspection (summarizes operations, network, fees, signers without leaking inputs)
- Transaction failure classifier: retryable/terminal/expired/unknown with recovery hints for ContractExecutionError, NetworkError, send/get RPC responses, and raw errors

closes  #185
closes #186
closes #199
closes #202