### PR TITLE
feat(sdk): add retry policy configuration, audit receipt serializer, and release publication checklist

### DIFF
--- a/RELEASE_CHECKLIST.md
+++ b/RELEASE_CHECKLIST.md
@@ -1,18 +1,39 @@
-# Release Checklist for Documentation Alignment
-## Introduction
-This checklist is designed to ensure that documentation stays aligned with the SDK surface during releases.
+# Release & Package Publication Verification Checklist
 
-## Pre-Release Steps
-1. Review key documentation for accuracy and completeness.
-2. Verify examples are up-to-date and work as expected.
-3. Check migration notes for relevance and correctness.
-4. Confirm support matrix aligns with current capabilities.
+## Overview
+This checklist defines the required pre-release and post-release verification steps for publishing the `@zk-payroll/core` SDK package to npm. Following this checklist ensures release repeatability, artifact integrity, and documentation alignment.
 
-## Release Steps
-1. Validate documentation changes against the SDK surface.
-2. Ensure all necessary documentation updates are included in the release.
-3. Review release notes for documentation relevance.
+---
 
-## Post-Release Steps
-1. Verify documentation is correctly published and accessible.
-2. Confirm that all links and references are valid.
+## 1. Pre-Publish Package Verification
+
+### A. Code & Version Quality
+- [ ] Version bump updated in `package.json` following Semantic Versioning (`npm version patch|minor|major`).
+- [ ] Working directory is clean with all changes committed (`git status`).
+- [ ] All unit, browser, and integration tests pass cleanly (`npm test`).
+- [ ] ESLint and Prettier checks pass without errors (`npm run lint` / `npm run format:check`).
+
+### B. Artifact & Build Integrity
+- [ ] TypeScript compilation succeeds with zero errors (`npm run build`).
+- [ ] Package bundle size meets target constraints (`npm run measure-bundle`).
+- [ ] Run `npm pack --dry-run` to inspect target release files and verify no sensitive test files, keys, or scratch scripts are included.
+
+### C. Documentation Alignment
+- [ ] Review `README.md` and API docs in `docs/` for accuracy against new SDK functions.
+- [ ] Verify `docs/SUPPORT_MATRIX.md` matches current Stellar/Soroban SDK dependency versions.
+- [ ] Ensure `CHANGELOG.md` reflects all notable features, bug fixes, and breaking changes.
+
+---
+
+## 2. CI/CD Workflows & Publication
+
+- [ ] **Continuous Integration**: Verify that [.github/workflows/ci.yml](.github/workflows/ci.yml) completes with green checks on the target release commit.
+- [ ] **Package Publishing**: Execute or monitor the [.github/workflows/publish.yml](.github/workflows/publish.yml) workflow for automated npm release.
+
+---
+
+## 3. Post-Publish Verification
+
+- [ ] Confirm `@zk-payroll/core` package is visible on npm registry (`npm info @zk-payroll/core`).
+- [ ] Verify clean installation in a fresh test project (`npm i @zk-payroll/core`).
+- [ ] Verify GitHub Release tag and release notes are published.

--- a/packages/core/src/audit/auditReceiptSerializer.ts
+++ b/packages/core/src/audit/auditReceiptSerializer.ts
@@ -1,0 +1,90 @@
+export interface AuditReceipt {
+  receiptId: string;
+  payrollId: string;
+  timestamp: string;
+  totalAmount: string;
+  currency: string;
+  recipientCount: number;
+  viewKeyId?: string;
+  complianceHash: string;
+  redacted: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditReceiptSerializeOptions {
+  redactPII?: boolean;
+  pretty?: boolean;
+}
+
+/**
+ * Validate that an unknown object conforms to the AuditReceipt interface shape.
+ */
+export function validateAuditReceiptShape(data: unknown): data is AuditReceipt {
+  if (typeof data !== "object" || data === null) {
+    return false;
+  }
+
+  const obj = data as Record<string, unknown>;
+
+  return (
+    typeof obj.receiptId === "string" &&
+    typeof obj.payrollId === "string" &&
+    typeof obj.timestamp === "string" &&
+    typeof obj.totalAmount === "string" &&
+    typeof obj.currency === "string" &&
+    typeof obj.recipientCount === "number" &&
+    typeof obj.complianceHash === "string" &&
+    typeof obj.redacted === "boolean"
+  );
+}
+
+/**
+ * Serialize an AuditReceipt into a canonical JSON string for audit/compliance storage.
+ */
+export function serializeAuditReceipt(
+  receipt: AuditReceipt,
+  options: AuditReceiptSerializeOptions = {}
+): string {
+  if (!validateAuditReceiptShape(receipt)) {
+    throw new Error("Invalid AuditReceipt shape provided for serialization");
+  }
+
+  const copy: AuditReceipt = { ...receipt };
+
+  if (options.redactPII) {
+    copy.redacted = true;
+    if (copy.metadata) {
+      const sanitizedMeta: Record<string, unknown> = {};
+      for (const [key, value] of Object.entries(copy.metadata)) {
+        if (!/name|email|ssn|address|pii/i.test(key)) {
+          sanitizedMeta[key] = value;
+        } else {
+          sanitizedMeta[key] = "[REDACTED]";
+        }
+      }
+      copy.metadata = sanitizedMeta;
+    }
+  }
+
+  return options.pretty
+    ? JSON.stringify(copy, null, 2)
+    : JSON.stringify(copy);
+}
+
+/**
+ * Deserialize a JSON string into a validated AuditReceipt.
+ */
+export function deserializeAuditReceipt(serialized: string): AuditReceipt {
+  try {
+    const parsed = JSON.parse(serialized);
+    if (!validateAuditReceiptShape(parsed)) {
+      throw new Error("Parsed JSON does not match required AuditReceipt schema");
+    }
+    return parsed;
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message.includes("AuditReceipt schema")) {
+      throw err;
+    }
+    throw new Error(`Failed to deserialize AuditReceipt: ${(err as Error).message}`);
+  }
+}

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -1,2 +1,3 @@
 export * from "./viewKeyHelpers";
 export * from "./eventNormalizer";
+export * from "./auditReceiptSerializer";

--- a/packages/core/src/config.ts
+++ b/packages/core/src/config.ts
@@ -1,11 +1,19 @@
 import { ProofGeneratorConfig } from "./crypto/IProofGenerator";
 import { StrKey } from "@stellar/stellar-sdk";
 
+export interface RetryPolicyConfig {
+  maxAttempts?: number;
+  initialDelayMs?: number;
+  maxDelayMs?: number;
+  backoffFactor?: number;
+}
+
 export interface ClientConfig {
   networkUrl: string;
   contractId: string;
   adminKey?: string;
   proofConfig?: ProofGeneratorConfig;
+  retryPolicy?: RetryPolicyConfig;
 }
 
 export class ConfigBuilder {
@@ -13,6 +21,7 @@ export class ConfigBuilder {
   private _contractId?: string;
   private _adminKey?: string;
   private _proofConfig?: ProofGeneratorConfig;
+  private _retryPolicy?: RetryPolicyConfig;
 
   constructor(preset?: Partial<ClientConfig>) {
     if (preset) {
@@ -20,6 +29,7 @@ export class ConfigBuilder {
       this._contractId = preset.contractId;
       this._adminKey = preset.adminKey;
       this._proofConfig = preset.proofConfig;
+      this._retryPolicy = preset.retryPolicy;
     }
   }
 
@@ -40,6 +50,11 @@ export class ConfigBuilder {
 
   public withProofConfig(config: ProofGeneratorConfig): this {
     this._proofConfig = config;
+    return this;
+  }
+
+  public withRetryPolicy(policy: RetryPolicyConfig): this {
+    this._retryPolicy = policy;
     return this;
   }
 
@@ -67,6 +82,15 @@ export class ConfigBuilder {
       if (!this._proofConfig.zkeyUrl) errors.push("proofConfig.zkeyUrl is required.");
     }
 
+    if (this._retryPolicy) {
+      if (this._retryPolicy.maxAttempts !== undefined && this._retryPolicy.maxAttempts < 1) {
+        errors.push("retryPolicy.maxAttempts must be at least 1.");
+      }
+      if (this._retryPolicy.initialDelayMs !== undefined && this._retryPolicy.initialDelayMs < 0) {
+        errors.push("retryPolicy.initialDelayMs cannot be negative.");
+      }
+    }
+
     if (errors.length > 0) {
       throw new Error(`Configuration validation failed:\n- ${errors.join("\n- ")}`);
     }
@@ -76,6 +100,7 @@ export class ConfigBuilder {
       contractId: this._contractId!,
       adminKey: this._adminKey,
       proofConfig: this._proofConfig,
+      retryPolicy: this._retryPolicy,
     };
   }
 }

--- a/packages/core/tests/auditReceiptSerializer.test.ts
+++ b/packages/core/tests/auditReceiptSerializer.test.ts
@@ -1,0 +1,66 @@
+import {
+  AuditReceipt,
+  serializeAuditReceipt,
+  deserializeAuditReceipt,
+  validateAuditReceiptShape,
+} from "../src/audit/auditReceiptSerializer";
+
+describe("auditReceiptSerializer", () => {
+  const mockReceipt: AuditReceipt = {
+    receiptId: "rcpt_12345",
+    payrollId: "pay_98765",
+    timestamp: "2026-07-27T12:00:00.000Z",
+    totalAmount: "15000000000",
+    currency: "USDC",
+    recipientCount: 25,
+    viewKeyId: "vk_abc123",
+    complianceHash: "0xabcdef1234567890",
+    redacted: false,
+    metadata: {
+      department: "Engineering",
+      auditorEmail: "audit@company.com",
+    },
+  };
+
+  describe("validateAuditReceiptShape", () => {
+    it("validates valid AuditReceipt shape", () => {
+      expect(validateAuditReceiptShape(mockReceipt)).toBe(true);
+    });
+
+    it("rejects invalid or incomplete shapes", () => {
+      expect(validateAuditReceiptShape(null)).toBe(false);
+      expect(validateAuditReceiptShape({ receiptId: "123" })).toBe(false);
+    });
+  });
+
+  describe("serializeAuditReceipt", () => {
+    it("serializes receipt to JSON string", () => {
+      const json = serializeAuditReceipt(mockReceipt);
+      expect(typeof json).toBe("string");
+      const parsed = JSON.parse(json);
+      expect(parsed.receiptId).toBe("rcpt_12345");
+      expect(parsed.redacted).toBe(false);
+    });
+
+    it("redacts PII fields when redactPII option is true", () => {
+      const json = serializeAuditReceipt(mockReceipt, { redactPII: true });
+      const parsed = JSON.parse(json);
+      expect(parsed.redacted).toBe(true);
+      expect(parsed.metadata.auditorEmail).toBe("[REDACTED]");
+      expect(parsed.metadata.department).toBe("Engineering");
+    });
+  });
+
+  describe("deserializeAuditReceipt", () => {
+    it("deserializes valid JSON string back to AuditReceipt", () => {
+      const json = serializeAuditReceipt(mockReceipt);
+      const restored = deserializeAuditReceipt(json);
+      expect(restored).toEqual(mockReceipt);
+    });
+
+    it("throws error for malformed JSON or invalid schema", () => {
+      expect(() => deserializeAuditReceipt("{ bad json")).toThrow();
+      expect(() => deserializeAuditReceipt(JSON.stringify({ random: "data" }))).toThrow();
+    });
+  });
+});

--- a/packages/core/tests/config.test.ts
+++ b/packages/core/tests/config.test.ts
@@ -75,4 +75,32 @@ describe("ConfigBuilder and ConfigPresets", () => {
       expect(config.networkUrl).toBe("https://soroban-rpc.mainnet.stellar.org");
     });
   });
+
+  describe("RetryPolicyConfig", () => {
+    it("should allow configuring custom retry policy", () => {
+      const config = new ConfigBuilder()
+        .withNetworkUrl("https://soroban-testnet.stellar.org")
+        .withContractId("CAKZGMMMJOHMSZ5V3DYKCUDNTIWBG57MAMFJDSVICNWUNVXLX6EZN3NC")
+        .withRetryPolicy({
+          maxAttempts: 5,
+          initialDelayMs: 250,
+          maxDelayMs: 5000,
+          backoffFactor: 2,
+        })
+        .build();
+
+      expect(config.retryPolicy).toBeDefined();
+      expect(config.retryPolicy?.maxAttempts).toBe(5);
+      expect(config.retryPolicy?.initialDelayMs).toBe(250);
+    });
+
+    it("should fail validation if maxAttempts is less than 1", () => {
+      const builder = new ConfigBuilder()
+        .withNetworkUrl("https://soroban-testnet.stellar.org")
+        .withContractId("CAKZGMMMJOHMSZ5V3DYKCUDNTIWBG57MAMFJDSVICNWUNVXLX6EZN3NC")
+        .withRetryPolicy({ maxAttempts: 0 });
+
+      expect(() => builder.build()).toThrow("retryPolicy.maxAttempts must be at least 1.");
+    });
+  });
 });


### PR DESCRIPTION
## Description
This PR resolves issues #204, #201, and #100 by introducing configurable SDK retry controls, an audit receipt serializer with PII redaction capabilities, and a package publication release checklist.

1. **Retry Policy Configuration (Issue #204)**:
   - Added `RetryPolicyConfig` interface and `withRetryPolicy` to `ConfigBuilder` and `ClientConfig` in `packages/core/src/config.ts`.
   - Allows explicit control over `maxAttempts`, `initialDelayMs`, `maxDelayMs`, and `backoffFactor`.

2. **Audit Receipt Serializer (Issue #201)**:
   - Created `AuditReceiptSerializer` in `packages/core/src/audit/auditReceiptSerializer.ts`.
   - Implements `serializeAuditReceipt`, `deserializeAuditReceipt`, and `validateAuditReceiptShape` with optional PII redaction.

3. **Release & Publication Verification Checklist (Issue #100)**:
   - Updated `RELEASE_CHECKLIST.md` with pre-publish code quality, build artifact, and documentation verification steps.
   - Linked publication workflows `.github/workflows/publish.yml` and `.github/workflows/ci.yml`.

Closes #204
Closes #201
Closes #100