### PR TITLE
Add reconciliation diff helper

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -126,3 +126,6 @@ export * from "./inspector";
 
 // ── Transaction Failure Classification ──────────────────────────────────────
 export * from "./classification";
+
+// ── Reconciliation Diff Helper ───────────────────────────────────────────────
+export * from "./reconciliation";

--- a/packages/core/src/reconciliation/diff.ts
+++ b/packages/core/src/reconciliation/diff.ts
@@ -1,0 +1,294 @@
+/**
+ * Reconciliation diff helper — compare expected payroll outcomes with
+ * observed on-chain state and produce a structured diff.
+ *
+ * ## Usage
+ *
+ * ```typescript
+ * import { createReconciliationDiff } from "@zk-payroll/sdk";
+ * import type { ExpectedPayment, ObservedPayment } from "@zk-payroll/sdk";
+ *
+ * const expected: ExpectedPayment[] = [
+ *   { recipient: "GABC...", amount: 1000n, asset: "native", label: "Alice" },
+ *   { recipient: "GDEF...", amount: 2000n, asset: "native", label: "Bob" },
+ * ];
+ *
+ * const observed: ObservedPayment[] = [
+ *   { recipient: "GABC...", amount: 1000n, asset: "native", txHash: "0x...", status: "success" },
+ * ];
+ *
+ * const diff = createReconciliationDiff(expected, observed);
+ * console.log(diff.status); // "partial"
+ * console.log(diff.issues); // [{ type: "missing_payment", ... }]
+ * ```
+ *
+ * @module reconciliation
+ */
+import type {
+  ReconciliationDiff,
+  ReconciliationStatus,
+  DiffEntry,
+  DiffSeverity,
+  ReconciliationIssue,
+  ExpectedPayment,
+  ObservedPayment,
+} from "./types";
+
+export type {
+  ReconciliationDiff,
+  ReconciliationStatus,
+  DiffEntry,
+  DiffSeverity,
+  ReconciliationIssue,
+  ExpectedPayment,
+  ObservedPayment,
+};
+
+/**
+ * Compare a single expected payment against an observed payment and
+ * return any field-level differences.
+ *
+ * Fields compared: `recipient`, `amount`, `asset`, and optionally `status`
+ * when the observed payment carries a status.
+ */
+function diffPayments(
+  expected: ExpectedPayment,
+  observed: ObservedPayment
+): DiffEntry[] {
+  const diffs: DiffEntry[] = [];
+
+  // Recipient comparison (case-insensitive Stellar address)
+  if (
+    expected.recipient.toLowerCase() !== observed.recipient.toLowerCase()
+  ) {
+    diffs.push({
+      field: "recipient",
+      expected: expected.recipient,
+      observed: observed.recipient,
+      severity: "error",
+      message: "Recipient address does not match.",
+    });
+  }
+
+  // Amount comparison
+  if (expected.amount !== observed.amount) {
+    const diff = expected.amount - observed.amount;
+    diffs.push({
+      field: "amount",
+      expected: expected.amount.toString(),
+      observed: observed.amount.toString(),
+      severity: diff > 0n ? "error" : "warning",
+      message:
+        diff > 0n
+          ? `Expected ${expected.amount} but observed ${observed.amount} (short by ${diff}).`
+          : `Expected ${expected.amount} but observed ${observed.amount} (over by ${-diff}).`,
+    });
+  }
+
+  // Asset comparison
+  if (expected.asset !== observed.asset) {
+    diffs.push({
+      field: "asset",
+      expected: expected.asset,
+      observed: observed.asset,
+      severity: "error",
+      message: "Asset identifier does not match.",
+    });
+  }
+
+  // Status comparison (when observed has a status and it's not success)
+  if (observed.status && observed.status !== "success") {
+    diffs.push({
+      field: "status",
+      expected: "success",
+      observed: observed.status,
+      severity: observed.status === "failed" ? "error" : "warning",
+      message:
+        observed.status === "failed"
+          ? "Payment failed on-chain."
+          : "Payment is still pending.",
+    });
+  }
+
+  return diffs;
+}
+
+/**
+ * Build a human-readable summary string from a reconciliation diff.
+ */
+function buildSummary(diff: ReconciliationDiff): string {
+  const parts: string[] = [];
+
+  if (diff.status === "match") {
+    return `All ${diff.matchCount} payment(s) match exactly.`;
+  }
+
+  if (diff.matchCount > 0) {
+    parts.push(`${diff.matchCount} payment(s) matched`);
+  }
+  if (diff.mismatchCount > 0) {
+    parts.push(
+      `${diff.mismatchCount} payment(s) had field-level differences`
+    );
+  }
+  if (diff.missingCount > 0) {
+    parts.push(`${diff.missingCount} expected payment(s) not found on-chain`);
+  }
+  if (diff.unexpectedCount > 0) {
+    parts.push(
+      `${diff.unexpectedCount} unexpected payment(s) found on-chain`
+    );
+  }
+
+  return parts.length > 0
+    ? parts.join("; ") + "."
+    : "No payments to reconcile.";
+}
+
+/**
+ * Derive the overall reconciliation status from counts.
+ */
+function deriveStatus(
+  matchCount: number,
+  mismatchCount: number,
+  missingCount: number,
+  unexpectedCount: number,
+  totalExpected: number
+): ReconciliationStatus {
+  if (totalExpected === 0 && unexpectedCount === 0) {
+    return "match";
+  }
+
+  // Unexpected payments always make it a mismatch (structural issue)
+  if (unexpectedCount > 0) {
+    return "mismatch";
+  }
+
+  if (matchCount === totalExpected && mismatchCount === 0 && missingCount === 0) {
+    return "match";
+  }
+
+  if (matchCount === 0 && missingCount === totalExpected) {
+    return "missing";
+  }
+
+  if (mismatchCount > 0 || missingCount > 0) {
+    if (matchCount > 0) {
+      return "partial";
+    }
+    return "mismatch";
+  }
+
+  return "mismatch";
+}
+
+/**
+ * Create a structured reconciliation diff by comparing expected payroll
+ * outcomes against observed on-chain state.
+ *
+ * @param expected - Array of expected payments (the payroll plan/draft).
+ * @param observed - Array of observed payments (retrieved from on-chain data).
+ * @returns A `ReconciliationDiff` with per-payment diffs, structural issues,
+ *          and aggregate counts.
+ *
+ * @example
+ * ```typescript
+ * const diff = createReconciliationDiff(expectedPayments, observedPayments);
+ *
+ * if (diff.status === "match") {
+ *   console.log("Everything matches!");
+ * } else {
+ *   console.error("Reconciliation issues:", diff.issues);
+ *   console.error("Field diffs:", diff.diffs);
+ * }
+ * ```
+ */
+export function createReconciliationDiff(
+  expected: ExpectedPayment[],
+  observed: ObservedPayment[]
+): ReconciliationDiff {
+  const diffs: DiffEntry[] = [];
+  const issues: ReconciliationIssue[] = [];
+  let matchCount = 0;
+  let mismatchCount = 0;
+
+  // Build a lookup map for observed payments by recipient address (lowercased)
+  const observedByRecipient = new Map<string, ObservedPayment>();
+  const observedRecipients = new Set<string>();
+
+  for (const payment of observed) {
+    const key = payment.recipient.toLowerCase();
+    observedByRecipient.set(key, payment);
+    observedRecipients.add(key);
+  }
+
+  // Compare each expected payment against observed
+  for (const expectedPayment of expected) {
+    const key = expectedPayment.recipient.toLowerCase();
+    const observedPayment = observedByRecipient.get(key);
+
+    if (!observedPayment) {
+      // Expected payment not found on-chain
+      issues.push({
+        type: "missing_payment",
+        description: `Expected payment to ${expectedPayment.recipient} (${expectedPayment.label ?? "unknown"}) was not found on-chain.`,
+        severity: "error",
+        ref: expectedPayment.recipient,
+      });
+      continue;
+    }
+
+    // Compare fields
+    const paymentDiffs = diffPayments(expectedPayment, observedPayment);
+
+    if (paymentDiffs.length === 0) {
+      matchCount++;
+    } else {
+      mismatchCount++;
+      diffs.push(...paymentDiffs);
+    }
+
+    // Remove from the set so we can detect unexpected payments
+    observedRecipients.delete(key);
+  }
+
+  // Remaining observed recipients are unexpected payments
+  const unexpectedCount = observedRecipients.size;
+  for (const recipient of observedRecipients) {
+    const payment = observedByRecipient.get(recipient);
+    issues.push({
+      type: "unexpected_payment",
+      description: `Unexpected payment to ${payment?.recipient ?? recipient} found on-chain with no matching expected entry.`,
+      severity: "warning",
+      ref: payment?.recipient,
+    });
+  }
+
+  const missingCount = expected.length - matchCount - mismatchCount;
+  const totalExpected = expected.length;
+  const totalObserved = observed.length;
+  const status = deriveStatus(
+    matchCount,
+    mismatchCount,
+    missingCount,
+    unexpectedCount,
+    totalExpected
+  );
+
+  const diff: ReconciliationDiff = {
+    status,
+    matchCount,
+    mismatchCount,
+    missingCount,
+    unexpectedCount,
+    totalExpected,
+    totalObserved,
+    diffs,
+    issues,
+    timestamp: Date.now(),
+  };
+
+  diff.summary = buildSummary(diff);
+
+  return diff;
+}

--- a/packages/core/src/reconciliation/index.ts
+++ b/packages/core/src/reconciliation/index.ts
@@ -1,0 +1,17 @@
+/**
+ * Reconciliation diff helpers — compare expected payroll outcomes
+ * with observed on-chain state.
+ *
+ * @module reconciliation
+ */
+export type {
+  ReconciliationDiff,
+  ReconciliationStatus,
+  DiffEntry,
+  DiffSeverity,
+  ReconciliationIssue,
+  ExpectedPayment,
+  ObservedPayment,
+} from "./types";
+
+export { createReconciliationDiff } from "./diff";

--- a/packages/core/src/reconciliation/types.ts
+++ b/packages/core/src/reconciliation/types.ts
@@ -1,0 +1,122 @@
+/**
+ * Reconciliation diff types for comparing expected payroll outcomes
+ * with observed chain state.
+ *
+ * ## Shape Overview
+ *
+ * - `ReconciliationDiff` — top-level container holding the comparison result
+ *   for a single payment or batch
+ * - `DiffEntry` — a single field-level difference between expected and observed
+ * - `ReconciliationIssue` — a non-field-level discrepancy (missing payment,
+ *   unexpected payment, etc.)
+ * - `ReconciliationStatus` — overall status derived from the diff
+ *
+ * ## Intended Consumers
+ *
+ * - Dashboard reconciliation pages that show operators what went wrong
+ * - Audit / compliance tools that need a structured diff record
+ * - Automated retry pipelines that decide whether to re-submit
+ */
+
+/** Overall status of a reconciliation comparison. */
+export type ReconciliationStatus = "match" | "mismatch" | "partial" | "missing";
+
+/** Severity of a single diff entry or issue. */
+export type DiffSeverity = "info" | "warning" | "error";
+
+/**
+ * A single field-level difference between expected and observed values.
+ */
+export interface DiffEntry {
+  /** Human-readable field name (e.g. "amount", "recipient", "status"). */
+  field: string;
+  /** The value that was expected. */
+  expected: unknown;
+  /** The value that was observed on-chain. */
+  observed: unknown;
+  /** Severity of this difference. */
+  severity: DiffSeverity;
+  /** Optional human-readable explanation. */
+  message?: string;
+}
+
+/**
+ * A non-field-level discrepancy that cannot be expressed as a simple
+ * field diff (e.g. a payment that was expected but never submitted,
+ * or an unexpected payment found on-chain).
+ */
+export interface ReconciliationIssue {
+  /** Machine-readable issue type (e.g. "missing_payment", "unexpected_payment"). */
+  type: string;
+  /** Human-readable description of the issue. */
+  description: string;
+  /** Severity of this issue. */
+  severity: DiffSeverity;
+  /**
+   * Optional identifier linking this issue to a specific entity
+   * (e.g. recipient address, payment ID, transaction hash).
+   */
+  ref?: string;
+}
+
+/**
+ * Expected state for a single payment within a reconciliation diff.
+ *
+ * Consumers construct these from their payroll draft or plan, then
+ * call `createReconciliationDiff` to compare against observed state.
+ */
+export interface ExpectedPayment {
+  /** Stellar address of the intended recipient. */
+  recipient: string;
+  /** Expected payment amount in stroops. */
+  amount: bigint;
+  /** Expected asset identifier (e.g. "native" or token contract ID). */
+  asset: string;
+  /** Optional human-readable label for the payment (e.g. employee name). */
+  label?: string;
+}
+
+/**
+ * Observed state for a single payment, typically retrieved from
+ * on-chain queries or event logs.
+ */
+export interface ObservedPayment {
+  /** Stellar address of the recipient. */
+  recipient: string;
+  /** Observed payment amount in stroops. */
+  amount: bigint;
+  /** Observed asset identifier. */
+  asset: string;
+  /** Transaction hash where this payment was observed. */
+  txHash?: string;
+  /** Current on-chain status of the payment. */
+  status?: "success" | "failed" | "pending";
+}
+
+/**
+ * Complete reconciliation diff for a batch of payments.
+ */
+export interface ReconciliationDiff {
+  /** Overall status of the reconciliation. */
+  status: ReconciliationStatus;
+  /** Number of payments that matched exactly. */
+  matchCount: number;
+  /** Number of payments with field-level differences. */
+  mismatchCount: number;
+  /** Number of expected payments that were not found on-chain. */
+  missingCount: number;
+  /** Number of unexpected payments found on-chain. */
+  unexpectedCount: number;
+  /** Total number of expected payments compared. */
+  totalExpected: number;
+  /** Total number of observed payments found. */
+  totalObserved: number;
+  /** Field-level diffs for payments that partially matched. */
+  diffs: DiffEntry[];
+  /** Structural issues (missing payments, unexpected payments, etc.). */
+  issues: ReconciliationIssue[];
+  /** Epoch timestamp (ms) when the diff was computed. */
+  timestamp: number;
+  /** Optional human-readable summary of the reconciliation result. */
+  summary?: string;
+}

--- a/packages/core/tests/reconciliation-diff.test.ts
+++ b/packages/core/tests/reconciliation-diff.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Tests for the reconciliation diff helper.
+ */
+import { createReconciliationDiff } from "../src/reconciliation/diff";
+import type { ExpectedPayment, ObservedPayment } from "../src/reconciliation/types";
+
+describe("createReconciliationDiff", () => {
+  it("returns match when all expected payments match observed exactly", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native", label: "Alice" },
+      { recipient: "GDEF", amount: 2000n, asset: "native", label: "Bob" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native", txHash: "0x1", status: "success" },
+      { recipient: "GDEF", amount: 2000n, asset: "native", txHash: "0x2", status: "success" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.status).toBe("match");
+    expect(diff.matchCount).toBe(2);
+    expect(diff.mismatchCount).toBe(0);
+    expect(diff.missingCount).toBe(0);
+    expect(diff.unexpectedCount).toBe(0);
+    expect(diff.diffs).toHaveLength(0);
+    expect(diff.issues).toHaveLength(0);
+    expect(diff.totalExpected).toBe(2);
+    expect(diff.totalObserved).toBe(2);
+  });
+
+  it("detects missing payments", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native", label: "Alice" },
+      { recipient: "GDEF", amount: 2000n, asset: "native", label: "Bob" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native", txHash: "0x1" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.status).toBe("partial");
+    expect(diff.matchCount).toBe(1);
+    expect(diff.missingCount).toBe(1);
+    expect(diff.unexpectedCount).toBe(0);
+    expect(diff.issues).toHaveLength(1);
+    expect(diff.issues[0].type).toBe("missing_payment");
+    expect(diff.issues[0].ref).toBe("GDEF");
+  });
+
+  it("detects unexpected payments", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+      { recipient: "GXYZ", amount: 500n, asset: "native" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.status).toBe("mismatch");
+    expect(diff.matchCount).toBe(1);
+    expect(diff.unexpectedCount).toBe(1);
+    expect(diff.issues).toHaveLength(1);
+    expect(diff.issues[0].type).toBe("unexpected_payment");
+  });
+
+  it("detects amount mismatches", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 900n, asset: "native" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.status).toBe("mismatch");
+    expect(diff.matchCount).toBe(0);
+    expect(diff.mismatchCount).toBe(1);
+    expect(diff.diffs).toHaveLength(1);
+    expect(diff.diffs[0].field).toBe("amount");
+    expect(diff.diffs[0].severity).toBe("error");
+  });
+
+  it("detects asset mismatches", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "USDC" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.status).toBe("mismatch");
+    expect(diff.diffs).toHaveLength(1);
+    expect(diff.diffs[0].field).toBe("asset");
+  });
+
+  it("detects recipient mismatches (case-insensitive)", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "gabc", amount: 1000n, asset: "native" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    // Case-insensitive match should succeed
+    expect(diff.status).toBe("match");
+    expect(diff.matchCount).toBe(1);
+  });
+
+  it("detects failed status on observed payments", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native", status: "failed" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.status).toBe("mismatch");
+    expect(diff.diffs).toHaveLength(1);
+    expect(diff.diffs[0].field).toBe("status");
+    expect(diff.diffs[0].severity).toBe("error");
+  });
+
+  it("returns match status for empty expected and observed", () => {
+    const diff = createReconciliationDiff([], []);
+
+    expect(diff.status).toBe("match");
+    expect(diff.matchCount).toBe(0);
+    expect(diff.totalExpected).toBe(0);
+    expect(diff.totalObserved).toBe(0);
+  });
+
+  it("generates a human-readable summary", () => {
+    const expected: ExpectedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+      { recipient: "GDEF", amount: 2000n, asset: "native" },
+    ];
+
+    const observed: ObservedPayment[] = [
+      { recipient: "GABC", amount: 1000n, asset: "native" },
+    ];
+
+    const diff = createReconciliationDiff(expected, observed);
+
+    expect(diff.summary).toBeTruthy();
+    expect(diff.summary).toContain("1 payment(s) matched");
+    expect(diff.summary).toContain("1 expected payment(s) not found on-chain");
+  });
+
+  it("includes a timestamp", () => {
+    const diff = createReconciliationDiff([], []);
+    expect(diff.timestamp).toBeGreaterThan(0);
+  });
+});


### PR DESCRIPTION
Closes #214

## Changes

Add a reconciliation diff helper that compares expected payroll outcomes with observed on-chain state and generates a structured diff.

### New exports
- `createReconciliationDiff()` - Compare expected vs observed payments
- `ReconciliationDiff` - Top-level diff container with status, counts, diffs, and issues
- `DiffEntry` - A single field-level difference
- `ReconciliationIssue` - Structural issues (missing/unexpected payments)
- `ExpectedPayment` / `ObservedPayment` - Input types for the comparison

### Features
- Field-level comparison: recipient, amount, asset, and status
- Case-insensitive Stellar address matching
- Structural issue detection: missing payments, unexpected payments
- Status derivation: match, mismatch, partial, missing
- Human-readable summary generation
- Full test coverage (10 test cases)