### PR TITLE
feat(sdk): add formatReconciliationDiff helper for log/CLI output (#214)

### DIFF
--- a/packages/core/src/reconciliation/format.ts
+++ b/packages/core/src/reconciliation/format.ts
@@ -1,0 +1,93 @@
+import type {
+  ReconciliationDiffCategory,
+  ReconciliationDiffResult,
+} from "./types";
+
+/**
+ * Human-readable label for each `ReconciliationDiffCategory`. Kept here
+ * (rather than inside `types.ts`) so the data model stays pure and any UI
+ * caller can use a different wording if it suits their context.
+ */
+const CATEGORY_LABELS: Record<ReconciliationDiffCategory, string> = {
+  match: "match",
+  missing: "missing",
+  failed_mismatch: "status mismatch",
+  amount_mismatch: "amount mismatch",
+  still_pending: "still pending",
+  unexpected: "unexpected",
+};
+
+const CATEGORY_RANK: Record<ReconciliationDiffCategory, number> = {
+  unexpected: 0,
+  failed_mismatch: 1,
+  amount_mismatch: 2,
+  missing: 3,
+  still_pending: 4,
+  match: 5,
+};
+
+export interface FormatReconciliationDiffOptions {
+  /** Indent prefix used for each entry line. Defaults to `"  "`. */
+  indent?: string;
+  /** Per-line terminator. Defaults to `"\n"`. */
+  newline?: string;
+}
+
+function formatCountSummary(counts: ReconciliationDiffResult["counts"]): string {
+  const interesting = (Object.keys(counts) as ReconciliationDiffCategory[])
+    .filter((c) => counts[c] > 0 && c !== "match" && c !== "still_pending")
+    .sort((a, b) => CATEGORY_RANK[a] - CATEGORY_RANK[b]);
+
+  const routine = counts.match + counts.still_pending;
+
+  const parts: string[] = [];
+  if (routine > 0) parts.push(`${routine} routine`);
+  for (const category of interesting) {
+    parts.push(`${counts[category]} ${CATEGORY_LABELS[category]}`);
+  }
+  return parts.length > 0 ? parts.join(", ") : "no entries";
+}
+
+/**
+ * Render a `ReconciliationDiffResult` as a multi-line, grep-friendly
+ * string suitable for logs, CLI output, or Slack notifications.
+ *
+ * The format is intentionally stable and machine-parseable so it can be
+ * diffed between runs without false positives:
+ *
+ * ```
+ * reconciliation: <status> — <count summary>
+ *   <recipient>: <category> — <reason>
+ *   ...
+ * ```
+ *
+ * Entries are sorted with non-match categories first so the most
+ * actionable lines appear at the top of a log output. Pure function,
+ * no side effects — safe to call repeatedly with the same result.
+ */
+export function formatReconciliationDiff(
+  result: ReconciliationDiffResult,
+  options: FormatReconciliationDiffOptions = {},
+): string {
+  const indent = options.indent ?? "  ";
+  const newline = options.newline ?? "\n";
+
+  const status = result.isFullyReconciled
+    ? "fully reconciled"
+    : "needs attention";
+
+  const header = `reconciliation: ${status} \u2014 ${formatCountSummary(result.counts)}`;
+
+  const sortedEntries = result.entries
+    .slice()
+    .sort((a, b) => CATEGORY_RANK[a.category] - CATEGORY_RANK[b.category]);
+
+  const lines = sortedEntries.map(
+    (entry) =>
+      `${indent}${entry.recipient}: ${CATEGORY_LABELS[entry.category]} \u2014 ${entry.reason}`,
+  );
+
+  return lines.length > 0
+    ? [header, ...lines].join(newline)
+    : header + newline;
+}

--- a/packages/core/src/reconciliation/index.ts
+++ b/packages/core/src/reconciliation/index.ts
@@ -1,7 +1,9 @@
 export { generateReconciliationDiff } from "./ReconciliationDiffGenerator";
+export { formatReconciliationDiff } from "./format";
 export type {
   ObservedPaymentState,
   ReconciliationDiffCategory,
   ReconciliationDiffEntry,
   ReconciliationDiffResult,
 } from "./types";
+export type { FormatReconciliationDiffOptions } from "./format";

--- a/packages/core/tests/reconciliation-format.test.ts
+++ b/packages/core/tests/reconciliation-format.test.ts
@@ -1,0 +1,128 @@
+/**
+ * Tests for formatReconciliationDiff (#214).
+ */
+import {
+  generateReconciliationDiff,
+  formatReconciliationDiff,
+} from "../src/reconciliation";
+import type { ObservedPaymentState } from "../src/reconciliation/types";
+import {
+  createExecutionSummary,
+  successOutcome,
+  failedOutcome,
+} from "../src/summary/PayrollExecutionSummary";
+
+const ALICE = "GALICE1234567890abcdef";
+const BOB = "GBOB1234567890abcdef";
+
+function observed(
+  partial: Partial<ObservedPaymentState> &
+    Pick<ObservedPaymentState, "recipient" | "onChainStatus">,
+): ObservedPaymentState {
+  return { observedAt: Date.now(), ...partial };
+}
+
+describe("formatReconciliationDiff", () => {
+  it("renders a header line and one line per entry for a mixed run", () => {
+    const expected = createExecutionSummary(
+      [
+        successOutcome(ALICE, 1000n, "native", "0xhash1"),
+        failedOutcome(BOB, 2000n, "native", "timeout"),
+      ],
+      500,
+    );
+    const observedState = [
+      observed({ recipient: ALICE, asset: "native", amount: 1000n, onChainStatus: "confirmed" }),
+      // Bob: nothing observed -> missing
+    ];
+
+    const diff = generateReconciliationDiff(expected, observedState);
+    const formatted = formatReconciliationDiff(diff);
+
+    expect(formatted).toContain("reconciliation: needs attention");
+    expect(formatted).toContain(`${ALICE}: match`);
+    expect(formatted).toContain(`${BOB}: missing`);
+    expect(formatted.split("\n").length).toBeGreaterThanOrEqual(3);
+  });
+
+  it("sorts actionable categories before matches so logs highlight problems", () => {
+    const expected = createExecutionSummary(
+      [
+        successOutcome(ALICE, 1000n, "native", "0xhash1"),
+        successOutcome(BOB, 2000n, "native", "0xhash2"),
+      ],
+      500,
+    );
+    const observedState = [
+      observed({ recipient: ALICE, asset: "native", amount: 1000n, onChainStatus: "confirmed" }),
+      observed({ recipient: BOB, asset: "native", onChainStatus: "failed" }),
+    ];
+
+    const diff = generateReconciliationDiff(expected, observedState);
+    const formatted = formatReconciliationDiff(diff);
+    const lines = formatted.split("\n");
+    const bobLine = lines.find((l) => l.includes(BOB));
+    const aliceLine = lines.find((l) => l.includes(ALICE));
+
+    expect(bobLine).toBeDefined();
+    expect(aliceLine).toBeDefined();
+    expect(lines.indexOf(bobLine!)).toBeLessThan(lines.indexOf(aliceLine!));
+  });
+
+  it("uses 'fully reconciled' status when every entry is routine", () => {
+    const expected = createExecutionSummary(
+      [successOutcome(ALICE, 1000n, "native", "0xhash1")],
+      500,
+    );
+    const observedState = [
+      observed({ recipient: ALICE, asset: "native", amount: 1000n, onChainStatus: "confirmed" }),
+    ];
+
+    const diff = generateReconciliationDiff(expected, observedState);
+    const formatted = formatReconciliationDiff(diff);
+
+    expect(formatted.startsWith("reconciliation: fully reconciled")).toBe(true);
+    expect(formatted).toContain("1 routine");
+  });
+
+  it("reports no entries for an empty run", () => {
+    const expected = createExecutionSummary([], 0);
+    const diff = generateReconciliationDiff(expected, []);
+    const formatted = formatReconciliationDiff(diff);
+
+    expect(formatted).toContain("reconciliation: fully reconciled");
+    expect(formatted).toContain("no entries");
+  });
+
+  it("respects custom indent and newline options", () => {
+    const expected = createExecutionSummary(
+      [successOutcome(ALICE, 1000n, "native", "0xhash1")],
+      500,
+    );
+    const observedState = [
+      observed({ recipient: ALICE, asset: "native", amount: 1000n, onChainStatus: "confirmed" }),
+    ];
+
+    const diff = generateReconciliationDiff(expected, observedState);
+    const formatted = formatReconciliationDiff(diff, {
+      indent: "----",
+      newline: "\r\n",
+    });
+
+    expect(formatted).toContain("----" + ALICE);
+    expect(formatted).toContain("\r\n");
+  });
+
+  it("is a pure function (calling twice yields identical output)", () => {
+    const expected = createExecutionSummary(
+      [successOutcome(ALICE, 1000n, "native", "0xhash1")],
+      500,
+    );
+    const observedState = [
+      observed({ recipient: ALICE, asset: "native", amount: 1000n, onChainStatus: "confirmed" }),
+    ];
+    const diff = generateReconciliationDiff(expected, observedState);
+
+    expect(formatReconciliationDiff(diff)).toBe(formatReconciliationDiff(diff));
+  });
+});


### PR DESCRIPTION
Closes #214

## Summary
Adds a small, pure formatReconciliationDiff helper next to the existing generateReconciliationDiff so consumers can render a reconciliation diff as a stable, log-friendly, grep-friendly string for CLI output, log files, or Slack notifications.

## Why
Per the issue: reconciliation diffs are essential for fast operational debugging. The diff generator already classifies every expected-vs-observed comparison, but writing a presentable summary by hand is repetitive. A formatter centralises that work so every consumer (the dashboard, scripts, incident bots) ends up with the same shape.

## What
- New packages/core/src/reconciliation/format.ts: formatReconciliationDiff(result, options?) returns a multi-line string with a stable header, sorted entries (actionable categories first), per-recipient lines, and a configurable indent / newline. Pure function, no side effects, deterministic output.
- packages/core/src/reconciliation/index.ts: re-exports formatReconciliationDiff and the new FormatReconciliationDiffOptions type.
- New packages/core/tests/reconciliation-format.test.ts: covers the header line, category sort order, fully-reconciled vs needs-attention status, the no-entries case, custom indent/newline options, and determinism (two calls produce identical output).

## Notes
- This PR does not modify generateReconciliationDiff or the existing reconciliation-diff.test.ts suite; both still pass (jest --testPathPattern=reconciliation reports 18/18 tests passing).