### PR TITLE
feat: add contract state indexer (#169)

### DIFF
--- a/docs/indexer.md
+++ b/docs/indexer.md
@@ -1,0 +1,113 @@
+# Contract State Indexer
+
+The SDK contract-state indexer reconstructs a normalized payroll domain view from
+paginated contract readers. It is intended for dashboards, backends, audit jobs,
+and reconciliation tools that should not each reinvent contract-state parsing.
+
+## Quick start
+
+```ts
+import { ContractStateIndexer, ContractStateReader } from "@zk-payroll/core";
+
+const reader: ContractStateReader = {
+  async listCompanies({ cursor, limit }) {
+    return contractReader.fetchCompanies({ cursor, limit });
+  },
+  async listEmployees(companyId, { cursor, limit }) {
+    return contractReader.fetchEmployees(companyId, { cursor, limit });
+  },
+  async listPayrollRuns(companyId, { cursor, limit }) {
+    return contractReader.fetchPayrollRuns(companyId, { cursor, limit });
+  },
+  async listContractEvents(companyId, { cursor, limit }) {
+    return contractReader.fetchEvents(companyId, { cursor, limit });
+  },
+  async listCommitments(companyId, { cursor, limit }) {
+    return contractReader.fetchCommitments(companyId, { cursor, limit });
+  },
+  async listAuditPermissions(companyId, { cursor, limit }) {
+    return contractReader.fetchAuditPermissions(companyId, { cursor, limit });
+  },
+};
+
+const result = await new ContractStateIndexer(reader).index({ pageSize: 100 });
+
+console.log(result.companies);
+console.log(result.diagnostics.warnings);
+```
+
+## Normalized view
+
+`ContractStateIndexer.index()` returns:
+
+- `companies`
+- `employees`
+- `payrollRuns`
+- `events`
+- `commitments`
+- `auditPermissions`
+- `diagnostics`
+- `checkpoint`
+
+Every record is keyed with stable SDK-level identifiers so consumers can build
+maps, tables, and reconciliation reports without depending on raw contract
+storage layout.
+
+## Diagnostics
+
+The indexer separates consistency findings by severity:
+
+- `warnings`: non-blocking inconsistencies, such as duplicate commitments or
+  expired audit permissions.
+- `recoverableErrors`: missing references and orphaned records that consumers
+  can display or quarantine while continuing to load the rest of the dataset.
+- `fatalErrors`: corrupted event data, invalid timestamps, or checkpoint resume
+  failures that should stop privileged automation until reviewed.
+
+Handled consistency checks include:
+
+- missing employee references from payroll runs, commitments, and events
+- orphan payroll runs
+- missing payroll-run references
+- mismatched event data
+- duplicate commitments
+- stale audit permissions
+- corrupted event payloads
+
+## Pagination and checkpointing
+
+Readers must honor `{ cursor, limit }` and return `{ items, nextCursor }`.
+The indexer walks collections page by page, so large contracts do not require a
+single full-state read.
+
+Use `maxPages` for bounded background jobs:
+
+```ts
+const firstPass = await indexer.index({ pageSize: 100, maxPages: 20 });
+
+if (!firstPass.checkpoint.complete) {
+  await saveCheckpoint(firstPass.checkpoint);
+}
+
+const resumed = await indexer.index({
+  pageSize: 100,
+  checkpoint: await loadCheckpoint(),
+});
+```
+
+If a checkpoint stops in the middle of a company, implement `getCompany()` on
+the reader so the next run can resume that company safely.
+
+## Consumer guidance
+
+Dashboard consumers should show warnings inline and avoid hiding recoverable
+errors. Backend consumers should fail closed when `fatalErrors.length > 0`, but
+can usually continue read-only reporting when only warnings are present.
+
+For best performance:
+
+- start with `pageSize` between 50 and 200 records
+- persist checkpoints for scheduled jobs
+- keep raw event payloads available for audit drill-downs
+- treat diagnostics as part of the indexed result, not as logs that can be
+  discarded

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -156,3 +156,6 @@ export * from "./inspector";
 
 // ── Transaction Failure Classification ──────────────────────────────────────
 export * from "./classification";
+
+// Contract State Indexer
+export * from "./indexer";

--- a/packages/core/src/indexer/ContractStateIndexer.ts
+++ b/packages/core/src/indexer/ContractStateIndexer.ts
@@ -1,0 +1,528 @@
+import {
+  ContractStateIndexerOptions,
+  ContractStateIndexResult,
+  ContractStatePage,
+  ContractStateReader,
+  IndexedCommitmentRecord,
+  IndexedCompany,
+  IndexedContractEvent,
+  IndexedPayrollDomainView,
+  IndexedRecordId,
+  IndexerDiagnostic,
+  IndexingCheckpoint,
+} from "./types";
+
+const DEFAULT_INDEXER_PAGE_SIZE = 100;
+
+interface ReadBudget {
+  remainingPages?: number;
+}
+
+interface ReadPagesResult<T> {
+  items: T[];
+  nextCursor?: string;
+}
+
+export class ContractStateIndexer {
+  constructor(private readonly reader: ContractStateReader) {}
+
+  async index(options: ContractStateIndexerOptions = {}): Promise<ContractStateIndexResult> {
+    const pageSize = options.pageSize ?? DEFAULT_INDEXER_PAGE_SIZE;
+    const indexedAt = options.indexedAt ?? Math.floor(Date.now() / 1000);
+    const budget: ReadBudget = {
+      remainingPages: options.maxPages,
+    };
+
+    const checkpoint = this.createCheckpoint(options.checkpoint, indexedAt);
+    const domain: IndexedPayrollDomainView = {
+      companies: [],
+      employees: [],
+      payrollRuns: [],
+      events: [],
+      commitments: [],
+      auditPermissions: [],
+    };
+    const diagnostics: IndexerDiagnostic[] = [];
+
+    if (checkpoint.activeCompanyId) {
+      const resumed = await this.resumeActiveCompany(
+        checkpoint.activeCompanyId,
+        checkpoint,
+        domain,
+        pageSize,
+        budget,
+        diagnostics
+      );
+      if (!resumed) {
+        return this.toResult(domain, diagnostics, checkpoint, indexedAt);
+      }
+    }
+
+    const companyPages = await this.readPages(
+      (request) => this.reader.listCompanies(request),
+      pageSize,
+      budget,
+      checkpoint.companyCursor
+    );
+    domain.companies.push(...companyPages.items);
+    checkpoint.companyCursor = companyPages.nextCursor;
+
+    for (const company of companyPages.items) {
+      if (this.isBudgetExhausted(budget)) {
+        checkpoint.activeCompanyId = company.id;
+        checkpoint.complete = false;
+        return this.toResult(domain, diagnostics, checkpoint, indexedAt);
+      }
+
+      if (checkpoint.completedCompanyIds.includes(company.id)) {
+        continue;
+      }
+
+      const complete = await this.indexCompany(company, checkpoint, domain, pageSize, budget);
+      if (!complete) {
+        checkpoint.activeCompanyId = company.id;
+        checkpoint.complete = false;
+        return this.toResult(domain, diagnostics, checkpoint, indexedAt);
+      }
+
+      checkpoint.completedCompanyIds.push(company.id);
+      checkpoint.companyCursors[company.id] = { complete: true };
+    }
+
+    checkpoint.activeCompanyId = undefined;
+    checkpoint.complete = checkpoint.companyCursor === undefined;
+
+    this.addConsistencyDiagnostics(domain, diagnostics, indexedAt);
+    return this.toResult(domain, diagnostics, checkpoint, indexedAt);
+  }
+
+  private async resumeActiveCompany(
+    companyId: IndexedRecordId,
+    checkpoint: IndexingCheckpoint,
+    domain: IndexedPayrollDomainView,
+    pageSize: number,
+    budget: ReadBudget,
+    diagnostics: IndexerDiagnostic[]
+  ): Promise<boolean> {
+    if (!this.reader.getCompany) {
+      diagnostics.push({
+        severity: "fatal_error",
+        code: "CHECKPOINT_REQUIRES_COMPANY_LOOKUP",
+        message:
+          "Cannot resume an active company checkpoint because the reader does not implement getCompany().",
+        companyId,
+      });
+      checkpoint.complete = false;
+      return false;
+    }
+
+    const company = await this.reader.getCompany(companyId);
+    if (!company) {
+      diagnostics.push({
+        severity: "fatal_error",
+        code: "MISSING_COMPANY_REFERENCE",
+        message: `Cannot resume checkpoint because company ${companyId} is no longer readable.`,
+        companyId,
+      });
+      checkpoint.complete = false;
+      return false;
+    }
+
+    domain.companies.push(company);
+    const complete = await this.indexCompany(company, checkpoint, domain, pageSize, budget);
+    if (complete) {
+      checkpoint.completedCompanyIds.push(company.id);
+      checkpoint.companyCursors[company.id] = { complete: true };
+      checkpoint.activeCompanyId = undefined;
+    }
+
+    return complete;
+  }
+
+  private async indexCompany(
+    company: IndexedCompany,
+    checkpoint: IndexingCheckpoint,
+    domain: IndexedPayrollDomainView,
+    pageSize: number,
+    budget: ReadBudget
+  ): Promise<boolean> {
+    const companyCheckpoint = checkpoint.companyCursors[company.id] ?? {};
+    checkpoint.companyCursors[company.id] = companyCheckpoint;
+
+    const employees = await this.readPages(
+      (request) => this.reader.listEmployees(company.id, request),
+      pageSize,
+      budget,
+      companyCheckpoint.employeesCursor
+    );
+    domain.employees.push(...employees.items);
+    companyCheckpoint.employeesCursor = employees.nextCursor;
+    if (employees.nextCursor) return false;
+
+    const payrollRuns = await this.readPages(
+      (request) => this.reader.listPayrollRuns(company.id, request),
+      pageSize,
+      budget,
+      companyCheckpoint.payrollRunsCursor
+    );
+    domain.payrollRuns.push(...payrollRuns.items);
+    companyCheckpoint.payrollRunsCursor = payrollRuns.nextCursor;
+    if (payrollRuns.nextCursor) return false;
+
+    const events = await this.readPages(
+      (request) => this.reader.listContractEvents(company.id, request),
+      pageSize,
+      budget,
+      companyCheckpoint.eventsCursor
+    );
+    domain.events.push(...events.items);
+    companyCheckpoint.eventsCursor = events.nextCursor;
+    if (events.nextCursor) return false;
+
+    const commitments = await this.readPages(
+      (request) => this.reader.listCommitments(company.id, request),
+      pageSize,
+      budget,
+      companyCheckpoint.commitmentsCursor
+    );
+    domain.commitments.push(...commitments.items);
+    companyCheckpoint.commitmentsCursor = commitments.nextCursor;
+    if (commitments.nextCursor) return false;
+
+    const auditPermissions = await this.readPages(
+      (request) => this.reader.listAuditPermissions(company.id, request),
+      pageSize,
+      budget,
+      companyCheckpoint.auditPermissionsCursor
+    );
+    domain.auditPermissions.push(...auditPermissions.items);
+    companyCheckpoint.auditPermissionsCursor = auditPermissions.nextCursor;
+    companyCheckpoint.complete = auditPermissions.nextCursor === undefined;
+
+    return companyCheckpoint.complete === true;
+  }
+  private async readPages<T>(
+    readPage: (request: { cursor?: string; limit: number }) => Promise<ContractStatePage<T>>,
+    limit: number,
+    budget: ReadBudget,
+    cursor?: string
+  ): Promise<ReadPagesResult<T>> {
+    const items: T[] = [];
+    let nextCursor = cursor;
+
+    do {
+      if (this.isBudgetExhausted(budget)) {
+        return { items, nextCursor };
+      }
+
+      const page = await readPage({ cursor: nextCursor, limit });
+      this.consumePage(budget);
+      items.push(...page.items);
+      nextCursor = page.nextCursor;
+    } while (nextCursor !== undefined);
+
+    return { items };
+  }
+
+  private createCheckpoint(
+    input: IndexingCheckpoint | undefined,
+    indexedAt: number
+  ): IndexingCheckpoint {
+    return {
+      companyCursor: input?.companyCursor,
+      activeCompanyId: input?.activeCompanyId,
+      companyCursors: { ...(input?.companyCursors ?? {}) },
+      completedCompanyIds: [...(input?.completedCompanyIds ?? [])],
+      complete: false,
+      updatedAt: indexedAt,
+    };
+  }
+
+  private addConsistencyDiagnostics(
+    domain: IndexedPayrollDomainView,
+    diagnostics: IndexerDiagnostic[],
+    indexedAt: number
+  ): void {
+    const companyIds = new Set(domain.companies.map((company) => company.id));
+    const employeeKeys = new Set(
+      domain.employees.map((employee) => this.employeeKey(employee.companyId, employee.id))
+    );
+    const payrollRunKeys = new Set(
+      domain.payrollRuns.map((run) => this.payrollRunKey(run.companyId, run.id))
+    );
+    const commitmentKeys = new Map<string, IndexedCommitmentRecord>();
+
+    for (const employee of domain.employees) {
+      if (!companyIds.has(employee.companyId)) {
+        diagnostics.push({
+          severity: "recoverable_error",
+          code: "MISSING_COMPANY_REFERENCE",
+          message: `Employee ${employee.id} references missing company ${employee.companyId}.`,
+          companyId: employee.companyId,
+          employeeId: employee.id,
+          recordId: employee.id,
+        });
+      }
+    }
+
+    for (const run of domain.payrollRuns) {
+      if (!companyIds.has(run.companyId)) {
+        diagnostics.push({
+          severity: "recoverable_error",
+          code: "ORPHAN_PAYROLL_RUN",
+          message: `Payroll run ${run.id} references missing company ${run.companyId}.`,
+          companyId: run.companyId,
+          payrollRunId: run.id,
+          recordId: run.id,
+        });
+      }
+
+      for (const employeeId of run.employeeIds) {
+        if (!employeeKeys.has(this.employeeKey(run.companyId, employeeId))) {
+          diagnostics.push({
+            severity: "warning",
+            code: "MISSING_EMPLOYEE_REFERENCE",
+            message: `Payroll run ${run.id} references missing employee ${employeeId}.`,
+            companyId: run.companyId,
+            employeeId,
+            payrollRunId: run.id,
+            recordId: run.id,
+          });
+        }
+      }
+    }
+
+    for (const commitment of domain.commitments) {
+      if (!companyIds.has(commitment.companyId)) {
+        diagnostics.push({
+          severity: "recoverable_error",
+          code: "MISSING_COMPANY_REFERENCE",
+          message: `Commitment ${commitment.id} references missing company ${commitment.companyId}.`,
+          companyId: commitment.companyId,
+          recordId: commitment.id,
+        });
+      }
+
+      if (!employeeKeys.has(this.employeeKey(commitment.companyId, commitment.employeeId))) {
+        diagnostics.push({
+          severity: "recoverable_error",
+          code: "MISSING_EMPLOYEE_REFERENCE",
+          message: `Commitment ${commitment.id} references missing employee ${commitment.employeeId}.`,
+          companyId: commitment.companyId,
+          employeeId: commitment.employeeId,
+          payrollRunId: commitment.payrollRunId,
+          recordId: commitment.id,
+        });
+      }
+
+      if (
+        commitment.payrollRunId &&
+        !payrollRunKeys.has(this.payrollRunKey(commitment.companyId, commitment.payrollRunId))
+      ) {
+        diagnostics.push({
+          severity: "recoverable_error",
+          code: "MISSING_PAYROLL_RUN_REFERENCE",
+          message: `Commitment ${commitment.id} references missing payroll run ${commitment.payrollRunId}.`,
+          companyId: commitment.companyId,
+          employeeId: commitment.employeeId,
+          payrollRunId: commitment.payrollRunId,
+          recordId: commitment.id,
+        });
+      }
+
+      const duplicateKey = [
+        commitment.companyId,
+        commitment.employeeId,
+        commitment.payrollRunId ?? "",
+        commitment.commitmentHash,
+      ].join(":");
+      const existing = commitmentKeys.get(duplicateKey);
+      if (existing) {
+        diagnostics.push({
+          severity: "warning",
+          code: "DUPLICATE_COMMITMENT",
+          message: `Commitments ${existing.id} and ${commitment.id} share the same employee/run/hash identity.`,
+          companyId: commitment.companyId,
+          employeeId: commitment.employeeId,
+          payrollRunId: commitment.payrollRunId,
+          recordId: commitment.id,
+          details: { duplicateOf: existing.id },
+        });
+      } else {
+        commitmentKeys.set(duplicateKey, commitment);
+      }
+    }
+
+    for (const event of domain.events) {
+      this.validateEvent(event, domain, companyIds, employeeKeys, payrollRunKeys, diagnostics);
+    }
+
+    for (const permission of domain.auditPermissions) {
+      if (!companyIds.has(permission.companyId)) {
+        diagnostics.push({
+          severity: "recoverable_error",
+          code: "MISSING_COMPANY_REFERENCE",
+          message: `Audit permission ${permission.id} references missing company ${permission.companyId}.`,
+          companyId: permission.companyId,
+          recordId: permission.id,
+        });
+      }
+
+      const isExpired = permission.expiresAt !== undefined && permission.expiresAt <= indexedAt;
+      const isRevoked = permission.revokedAt !== undefined && permission.revokedAt <= indexedAt;
+      if (isExpired || isRevoked) {
+        diagnostics.push({
+          severity: "warning",
+          code: "STALE_AUDIT_PERMISSION",
+          message: `Audit permission ${permission.id} is ${isRevoked ? "revoked" : "expired"}.`,
+          companyId: permission.companyId,
+          recordId: permission.id,
+          details: { expiresAt: permission.expiresAt, revokedAt: permission.revokedAt },
+        });
+      }
+    }
+  }
+
+  private validateEvent(
+    event: IndexedContractEvent,
+    domain: IndexedPayrollDomainView,
+    companyIds: Set<string>,
+    employeeKeys: Set<string>,
+    payrollRunKeys: Set<string>,
+    diagnostics: IndexerDiagnostic[]
+  ): void {
+    if (!event.id || !event.type || !Number.isFinite(event.occurredAt)) {
+      diagnostics.push({
+        severity: "fatal_error",
+        code: "CORRUPTED_EVENT_DATA",
+        message: `Event ${event.id || "<unknown>"} is missing a stable id, type, or timestamp.`,
+        recordId: event.id,
+      });
+      return;
+    }
+
+    if (event.amount !== undefined && event.amount < 0n) {
+      diagnostics.push({
+        severity: "fatal_error",
+        code: "CORRUPTED_EVENT_DATA",
+        message: `Event ${event.id} contains a negative amount.`,
+        companyId: event.companyId,
+        employeeId: event.employeeId,
+        payrollRunId: event.payrollRunId,
+        recordId: event.id,
+      });
+    }
+
+    if (event.companyId && !companyIds.has(event.companyId)) {
+      diagnostics.push({
+        severity: "recoverable_error",
+        code: "MISSING_COMPANY_REFERENCE",
+        message: `Event ${event.id} references missing company ${event.companyId}.`,
+        companyId: event.companyId,
+        recordId: event.id,
+      });
+    }
+
+    if (
+      event.companyId &&
+      event.employeeId &&
+      !employeeKeys.has(this.employeeKey(event.companyId, event.employeeId))
+    ) {
+      diagnostics.push({
+        severity: "recoverable_error",
+        code: "MISSING_EMPLOYEE_REFERENCE",
+        message: `Event ${event.id} references missing employee ${event.employeeId}.`,
+        companyId: event.companyId,
+        employeeId: event.employeeId,
+        payrollRunId: event.payrollRunId,
+        recordId: event.id,
+      });
+    }
+
+    if (
+      event.companyId &&
+      event.payrollRunId &&
+      !payrollRunKeys.has(this.payrollRunKey(event.companyId, event.payrollRunId))
+    ) {
+      diagnostics.push({
+        severity: "recoverable_error",
+        code: "MISSING_PAYROLL_RUN_REFERENCE",
+        message: `Event ${event.id} references missing payroll run ${event.payrollRunId}.`,
+        companyId: event.companyId,
+        employeeId: event.employeeId,
+        payrollRunId: event.payrollRunId,
+        recordId: event.id,
+      });
+      return;
+    }
+
+    const payrollRun = domain.payrollRuns.find(
+      (run) => run.companyId === event.companyId && run.id === event.payrollRunId
+    );
+    if (payrollRun && event.employeeId && !payrollRun.employeeIds.includes(event.employeeId)) {
+      diagnostics.push({
+        severity: "warning",
+        code: "MISMATCHED_EVENT_DATA",
+        message: `Event ${event.id} references employee ${event.employeeId}, which is not part of payroll run ${payrollRun.id}.`,
+        companyId: event.companyId,
+        employeeId: event.employeeId,
+        payrollRunId: event.payrollRunId,
+        recordId: event.id,
+      });
+    }
+
+    if (payrollRun?.totalAmount !== undefined && event.amount !== undefined) {
+      const payloadTotal = event.payload?.payrollRunTotal;
+      const expectedTotal =
+        typeof payloadTotal === "bigint" ? payloadTotal : payrollRun.totalAmount;
+      if (expectedTotal !== payrollRun.totalAmount) {
+        diagnostics.push({
+          severity: "warning",
+          code: "MISMATCHED_EVENT_DATA",
+          message: `Event ${event.id} reports a payroll total that differs from payroll run ${payrollRun.id}.`,
+          companyId: event.companyId,
+          employeeId: event.employeeId,
+          payrollRunId: event.payrollRunId,
+          recordId: event.id,
+        });
+      }
+    }
+  }
+
+  private toResult(
+    domain: IndexedPayrollDomainView,
+    diagnostics: IndexerDiagnostic[],
+    checkpoint: IndexingCheckpoint,
+    indexedAt: number
+  ): ContractStateIndexResult {
+    return {
+      ...domain,
+      indexedAt,
+      checkpoint,
+      diagnostics: {
+        warnings: diagnostics.filter((d) => d.severity === "warning"),
+        recoverableErrors: diagnostics.filter((d) => d.severity === "recoverable_error"),
+        fatalErrors: diagnostics.filter((d) => d.severity === "fatal_error"),
+        all: diagnostics,
+      },
+    };
+  }
+
+  private employeeKey(companyId: IndexedRecordId, employeeId: IndexedRecordId): string {
+    return `${companyId}:${employeeId}`;
+  }
+
+  private payrollRunKey(companyId: IndexedRecordId, payrollRunId: IndexedRecordId): string {
+    return `${companyId}:${payrollRunId}`;
+  }
+
+  private isBudgetExhausted(budget: ReadBudget): boolean {
+    return budget.remainingPages !== undefined && budget.remainingPages <= 0;
+  }
+
+  private consumePage(budget: ReadBudget): void {
+    if (budget.remainingPages !== undefined) {
+      budget.remainingPages -= 1;
+    }
+  }
+}

--- a/packages/core/src/indexer/index.ts
+++ b/packages/core/src/indexer/index.ts
@@ -1,0 +1,2 @@
+export { ContractStateIndexer } from "./ContractStateIndexer";
+export * from "./types";

--- a/packages/core/src/indexer/types.ts
+++ b/packages/core/src/indexer/types.ts
@@ -1,0 +1,185 @@
+export type IndexedRecordId = string;
+
+export type IndexedEmployeeStatus = "active" | "inactive";
+
+export type IndexedPayrollRunStatus = "draft" | "scheduled" | "executed" | "cancelled" | "failed";
+
+export interface IndexedTreasuryReference {
+  id: IndexedRecordId;
+  asset: string;
+  address?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IndexedCompany {
+  id: IndexedRecordId;
+  name?: string;
+  treasury?: IndexedTreasuryReference;
+  active?: boolean;
+  metadata?: Record<string, unknown>;
+  updatedAt?: number;
+}
+
+export interface IndexedEmployee {
+  id: IndexedRecordId;
+  companyId: IndexedRecordId;
+  walletAddress: string;
+  status: IndexedEmployeeStatus;
+  salary?: bigint;
+  token?: string;
+  metadata?: Record<string, unknown>;
+  updatedAt?: number;
+}
+
+export interface IndexedPayrollRun {
+  id: IndexedRecordId;
+  companyId: IndexedRecordId;
+  employeeIds: IndexedRecordId[];
+  cycleId?: string;
+  status: IndexedPayrollRunStatus;
+  totalAmount?: bigint;
+  treasuryId?: IndexedRecordId;
+  commitmentIds?: IndexedRecordId[];
+  eventIds?: IndexedRecordId[];
+  executedAt?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IndexedCommitmentRecord {
+  id: IndexedRecordId;
+  companyId: IndexedRecordId;
+  employeeId: IndexedRecordId;
+  payrollRunId?: IndexedRecordId;
+  commitmentHash: string;
+  amount?: bigint;
+  createdAt?: number;
+  revealed?: boolean;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IndexedAuditPermission {
+  id: IndexedRecordId;
+  companyId: IndexedRecordId;
+  auditor: string;
+  scope: string;
+  grantedAt: number;
+  expiresAt?: number;
+  revokedAt?: number;
+  metadata?: Record<string, unknown>;
+}
+
+export interface IndexedContractEvent {
+  id: IndexedRecordId;
+  type: string;
+  companyId?: IndexedRecordId;
+  employeeId?: IndexedRecordId;
+  payrollRunId?: IndexedRecordId;
+  commitmentHash?: string;
+  amount?: bigint;
+  occurredAt: number;
+  payload?: Record<string, unknown>;
+}
+
+export interface ContractStatePage<T> {
+  items: T[];
+  nextCursor?: string;
+}
+
+export interface ContractStatePageRequest {
+  cursor?: string;
+  limit: number;
+}
+
+export interface ContractStateReader {
+  getCompany?(companyId: IndexedRecordId): Promise<IndexedCompany | undefined>;
+  listCompanies(request: ContractStatePageRequest): Promise<ContractStatePage<IndexedCompany>>;
+  listEmployees(
+    companyId: IndexedRecordId,
+    request: ContractStatePageRequest
+  ): Promise<ContractStatePage<IndexedEmployee>>;
+  listPayrollRuns(
+    companyId: IndexedRecordId,
+    request: ContractStatePageRequest
+  ): Promise<ContractStatePage<IndexedPayrollRun>>;
+  listContractEvents(
+    companyId: IndexedRecordId,
+    request: ContractStatePageRequest
+  ): Promise<ContractStatePage<IndexedContractEvent>>;
+  listCommitments(
+    companyId: IndexedRecordId,
+    request: ContractStatePageRequest
+  ): Promise<ContractStatePage<IndexedCommitmentRecord>>;
+  listAuditPermissions(
+    companyId: IndexedRecordId,
+    request: ContractStatePageRequest
+  ): Promise<ContractStatePage<IndexedAuditPermission>>;
+}
+
+export interface CompanyIndexingCheckpoint {
+  employeesCursor?: string;
+  payrollRunsCursor?: string;
+  eventsCursor?: string;
+  commitmentsCursor?: string;
+  auditPermissionsCursor?: string;
+  complete?: boolean;
+}
+
+export interface IndexingCheckpoint {
+  companyCursor?: string;
+  activeCompanyId?: IndexedRecordId;
+  companyCursors: Record<IndexedRecordId, CompanyIndexingCheckpoint>;
+  completedCompanyIds: IndexedRecordId[];
+  complete: boolean;
+  updatedAt: number;
+}
+
+export interface ContractStateIndexerOptions {
+  pageSize?: number;
+  maxPages?: number;
+  indexedAt?: number;
+  checkpoint?: IndexingCheckpoint;
+}
+
+export type IndexerDiagnosticSeverity = "warning" | "recoverable_error" | "fatal_error";
+
+export type IndexerDiagnosticCode =
+  | "MISSING_COMPANY_REFERENCE"
+  | "MISSING_EMPLOYEE_REFERENCE"
+  | "ORPHAN_PAYROLL_RUN"
+  | "MISSING_PAYROLL_RUN_REFERENCE"
+  | "MISMATCHED_EVENT_DATA"
+  | "DUPLICATE_COMMITMENT"
+  | "STALE_AUDIT_PERMISSION"
+  | "CORRUPTED_EVENT_DATA"
+  | "CHECKPOINT_REQUIRES_COMPANY_LOOKUP";
+
+export interface IndexerDiagnostic {
+  severity: IndexerDiagnosticSeverity;
+  code: IndexerDiagnosticCode;
+  message: string;
+  companyId?: IndexedRecordId;
+  employeeId?: IndexedRecordId;
+  payrollRunId?: IndexedRecordId;
+  recordId?: IndexedRecordId;
+  details?: Record<string, unknown>;
+}
+
+export interface IndexedPayrollDomainView {
+  companies: IndexedCompany[];
+  employees: IndexedEmployee[];
+  payrollRuns: IndexedPayrollRun[];
+  events: IndexedContractEvent[];
+  commitments: IndexedCommitmentRecord[];
+  auditPermissions: IndexedAuditPermission[];
+}
+
+export interface ContractStateIndexResult extends IndexedPayrollDomainView {
+  indexedAt: number;
+  checkpoint: IndexingCheckpoint;
+  diagnostics: {
+    warnings: IndexerDiagnostic[];
+    recoverableErrors: IndexerDiagnostic[];
+    fatalErrors: IndexerDiagnostic[];
+    all: IndexerDiagnostic[];
+  };
+}

--- a/packages/core/tests/indexer.test.ts
+++ b/packages/core/tests/indexer.test.ts
@@ -1,0 +1,334 @@
+import {
+  ContractStateIndexer,
+  ContractStatePage,
+  ContractStateReader,
+  IndexedAuditPermission,
+  IndexedCommitmentRecord,
+  IndexedCompany,
+  IndexedContractEvent,
+  IndexedEmployee,
+  IndexedPayrollRun,
+} from "../src/indexer";
+
+type CollectionName =
+  "companies" | "employees" | "payrollRuns" | "events" | "commitments" | "auditPermissions";
+
+interface MockState {
+  companies: IndexedCompany[];
+  employees: Record<string, IndexedEmployee[]>;
+  payrollRuns: Record<string, IndexedPayrollRun[]>;
+  events: Record<string, IndexedContractEvent[]>;
+  commitments: Record<string, IndexedCommitmentRecord[]>;
+  auditPermissions: Record<string, IndexedAuditPermission[]>;
+}
+
+class MockContractStateReader implements ContractStateReader {
+  public readonly calls: Array<{ collection: CollectionName; companyId?: string; limit: number }> =
+    [];
+
+  constructor(private readonly state: MockState) {}
+
+  async getCompany(companyId: string): Promise<IndexedCompany | undefined> {
+    return this.state.companies.find((company) => company.id === companyId);
+  }
+
+  async listCompanies(request: {
+    cursor?: string;
+    limit: number;
+  }): Promise<ContractStatePage<IndexedCompany>> {
+    this.calls.push({ collection: "companies", limit: request.limit });
+    return this.page(this.state.companies, request);
+  }
+
+  async listEmployees(
+    companyId: string,
+    request: { cursor?: string; limit: number }
+  ): Promise<ContractStatePage<IndexedEmployee>> {
+    this.calls.push({ collection: "employees", companyId, limit: request.limit });
+    return this.page(this.state.employees[companyId] ?? [], request);
+  }
+
+  async listPayrollRuns(
+    companyId: string,
+    request: { cursor?: string; limit: number }
+  ): Promise<ContractStatePage<IndexedPayrollRun>> {
+    this.calls.push({ collection: "payrollRuns", companyId, limit: request.limit });
+    return this.page(this.state.payrollRuns[companyId] ?? [], request);
+  }
+
+  async listContractEvents(
+    companyId: string,
+    request: { cursor?: string; limit: number }
+  ): Promise<ContractStatePage<IndexedContractEvent>> {
+    this.calls.push({ collection: "events", companyId, limit: request.limit });
+    return this.page(this.state.events[companyId] ?? [], request);
+  }
+
+  async listCommitments(
+    companyId: string,
+    request: { cursor?: string; limit: number }
+  ): Promise<ContractStatePage<IndexedCommitmentRecord>> {
+    this.calls.push({ collection: "commitments", companyId, limit: request.limit });
+    return this.page(this.state.commitments[companyId] ?? [], request);
+  }
+
+  async listAuditPermissions(
+    companyId: string,
+    request: { cursor?: string; limit: number }
+  ): Promise<ContractStatePage<IndexedAuditPermission>> {
+    this.calls.push({ collection: "auditPermissions", companyId, limit: request.limit });
+    return this.page(this.state.auditPermissions[companyId] ?? [], request);
+  }
+
+  private page<T>(
+    items: T[],
+    request: { cursor?: string; limit: number }
+  ): Promise<ContractStatePage<T>> {
+    const start = request.cursor ? Number(request.cursor) : 0;
+    const end = start + request.limit;
+    return Promise.resolve({
+      items: items.slice(start, end),
+      nextCursor: end < items.length ? String(end) : undefined,
+    });
+  }
+}
+
+function makeCompleteState(): MockState {
+  return {
+    companies: [
+      {
+        id: "company-1",
+        name: "Acme",
+        treasury: { id: "treasury-1", asset: "USDC", address: "GASSET" },
+        active: true,
+      },
+    ],
+    employees: {
+      "company-1": [
+        {
+          id: "employee-1",
+          companyId: "company-1",
+          walletAddress: "GEMPLOYEE1",
+          status: "active",
+          salary: 1_000n,
+          token: "USDC",
+        },
+        {
+          id: "employee-2",
+          companyId: "company-1",
+          walletAddress: "GEMPLOYEE2",
+          status: "active",
+          salary: 2_000n,
+          token: "USDC",
+        },
+      ],
+    },
+    payrollRuns: {
+      "company-1": [
+        {
+          id: "run-1",
+          companyId: "company-1",
+          employeeIds: ["employee-1", "employee-2"],
+          status: "executed",
+          totalAmount: 3_000n,
+          commitmentIds: ["commitment-1", "commitment-2"],
+          eventIds: ["event-1"],
+        },
+      ],
+    },
+    events: {
+      "company-1": [
+        {
+          id: "event-1",
+          type: "payroll_run_executed",
+          companyId: "company-1",
+          payrollRunId: "run-1",
+          amount: 3_000n,
+          occurredAt: 1_800_000_000,
+          payload: { payrollRunTotal: 3_000n },
+        },
+      ],
+    },
+    commitments: {
+      "company-1": [
+        {
+          id: "commitment-1",
+          companyId: "company-1",
+          employeeId: "employee-1",
+          payrollRunId: "run-1",
+          commitmentHash: "hash-1",
+          amount: 1_000n,
+        },
+        {
+          id: "commitment-2",
+          companyId: "company-1",
+          employeeId: "employee-2",
+          payrollRunId: "run-1",
+          commitmentHash: "hash-2",
+          amount: 2_000n,
+        },
+      ],
+    },
+    auditPermissions: {
+      "company-1": [
+        {
+          id: "audit-1",
+          companyId: "company-1",
+          auditor: "GAUDITOR",
+          scope: "payroll:read",
+          grantedAt: 1_700_000_000,
+          expiresAt: 1_900_000_000,
+        },
+      ],
+    },
+  };
+}
+
+describe("ContractStateIndexer", () => {
+  it("reconstructs a normalized payroll domain view from complete contract state", async () => {
+    const reader = new MockContractStateReader(makeCompleteState());
+    const result = await new ContractStateIndexer(reader).index({
+      pageSize: 2,
+      indexedAt: 1_800_000_001,
+    });
+
+    expect(result.companies).toHaveLength(1);
+    expect(result.employees).toHaveLength(2);
+    expect(result.payrollRuns).toHaveLength(1);
+    expect(result.events).toHaveLength(1);
+    expect(result.commitments).toHaveLength(2);
+    expect(result.auditPermissions).toHaveLength(1);
+    expect(result.diagnostics.all).toHaveLength(0);
+    expect(result.checkpoint.complete).toBe(true);
+  });
+
+  it("reports recoverable missing references without crashing", async () => {
+    const state = makeCompleteState();
+    state.payrollRuns["company-1"][0].employeeIds.push("missing-employee");
+    state.commitments["company-1"].push({
+      id: "orphan-commitment",
+      companyId: "company-1",
+      employeeId: "missing-employee",
+      payrollRunId: "missing-run",
+      commitmentHash: "hash-orphan",
+    });
+
+    const result = await new ContractStateIndexer(new MockContractStateReader(state)).index({
+      indexedAt: 1_800_000_001,
+    });
+
+    expect(result.diagnostics.warnings.map((d) => d.code)).toContain("MISSING_EMPLOYEE_REFERENCE");
+    expect(result.diagnostics.recoverableErrors.map((d) => d.code)).toEqual(
+      expect.arrayContaining(["MISSING_EMPLOYEE_REFERENCE", "MISSING_PAYROLL_RUN_REFERENCE"])
+    );
+    expect(result.diagnostics.fatalErrors).toHaveLength(0);
+  });
+
+  it("detects duplicate commitments and stale audit permissions", async () => {
+    const state = makeCompleteState();
+    state.commitments["company-1"].push({
+      id: "commitment-duplicate",
+      companyId: "company-1",
+      employeeId: "employee-1",
+      payrollRunId: "run-1",
+      commitmentHash: "hash-1",
+    });
+    state.auditPermissions["company-1"][0].expiresAt = 1_799_999_999;
+
+    const result = await new ContractStateIndexer(new MockContractStateReader(state)).index({
+      indexedAt: 1_800_000_001,
+    });
+
+    expect(result.diagnostics.warnings.map((d) => d.code)).toEqual(
+      expect.arrayContaining(["DUPLICATE_COMMITMENT", "STALE_AUDIT_PERMISSION"])
+    );
+  });
+
+  it("emits typed fatal errors for corrupted event data", async () => {
+    const state = makeCompleteState();
+    state.events["company-1"].push({
+      id: "corrupt-event",
+      type: "payment_executed",
+      companyId: "company-1",
+      employeeId: "employee-1",
+      payrollRunId: "run-1",
+      amount: -1n,
+      occurredAt: 1_800_000_001,
+    });
+
+    const result = await new ContractStateIndexer(new MockContractStateReader(state)).index({
+      indexedAt: 1_800_000_001,
+    });
+
+    expect(result.diagnostics.fatalErrors).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "CORRUPTED_EVENT_DATA",
+          recordId: "corrupt-event",
+        }),
+      ])
+    );
+  });
+
+  it("detects mismatched event data against payroll run membership", async () => {
+    const state = makeCompleteState();
+    state.events["company-1"].push({
+      id: "mismatched-event",
+      type: "payment_executed",
+      companyId: "company-1",
+      employeeId: "employee-3",
+      payrollRunId: "run-1",
+      amount: 100n,
+      occurredAt: 1_800_000_001,
+    });
+    state.employees["company-1"].push({
+      id: "employee-3",
+      companyId: "company-1",
+      walletAddress: "GEMPLOYEE3",
+      status: "active",
+    });
+
+    const result = await new ContractStateIndexer(new MockContractStateReader(state)).index();
+
+    expect(result.diagnostics.warnings).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({
+          code: "MISMATCHED_EVENT_DATA",
+          recordId: "mismatched-event",
+        }),
+      ])
+    );
+  });
+
+  it("uses pagination for large datasets instead of assuming full-state reads", async () => {
+    const state = makeCompleteState();
+    state.employees["company-1"] = Array.from({ length: 250 }, (_, index) => ({
+      id: `employee-${index}`,
+      companyId: "company-1",
+      walletAddress: `GEMPLOYEE${index}`,
+      status: "active" as const,
+    }));
+    state.payrollRuns["company-1"][0].employeeIds = state.employees["company-1"].map(
+      (employee) => employee.id
+    );
+    state.commitments["company-1"] = [];
+
+    const reader = new MockContractStateReader(state);
+    const result = await new ContractStateIndexer(reader).index({ pageSize: 50 });
+    const employeeReads = reader.calls.filter((call) => call.collection === "employees");
+
+    expect(result.employees).toHaveLength(250);
+    expect(employeeReads).toHaveLength(5);
+    expect(employeeReads.every((call) => call.limit === 50)).toBe(true);
+    expect(result.checkpoint.complete).toBe(true);
+  });
+
+  it("returns an incomplete checkpoint when page budget is exhausted", async () => {
+    const reader = new MockContractStateReader(makeCompleteState());
+    const result = await new ContractStateIndexer(reader).index({ pageSize: 1, maxPages: 2 });
+
+    expect(result.checkpoint.complete).toBe(false);
+    expect(result.checkpoint.activeCompanyId).toBe("company-1");
+    expect(result.checkpoint.companyCursors["company-1"].employeesCursor).toBe("1");
+  });
+});


### PR DESCRIPTION
Closes #169

## Summary
Adds a reusable SDK contract-state indexer that reconstructs a normalized payroll domain view from paginated contract state readers, with typed consistency diagnostics and checkpoint support for safe resumable indexing.

## Changes
- Added `ContractStateIndexer` for indexing companies, employees, payroll runs, contract events, commitments, and audit permissions.
- Added normalized indexer domain types and typed diagnostic codes/severities.
- Added consistency checks for:
  - missing company / employee references
  - orphan payroll runs
  - missing payroll-run references
  - mismatched event data
  - duplicate commitments
  - stale audit permissions
  - corrupted event data
- Added checkpoint and `maxPages` support so consumers can resume large indexing jobs.
- Exported the indexer from the core SDK entrypoint.
- Added indexer documentation with usage, diagnostics, checkpointing, and performance guidance.
- Added tests covering complete, partial, corrupted, duplicate, stale, and large paginated datasets.

## Testing
- `npm.cmd run test -w packages/core -- indexer.test.ts`
- `npm.cmd run test -w packages/core`
- `npm.cmd run typecheck -w packages/core`
- `npm.cmd run build -w packages/core`
- Scoped ESLint on new indexer files

## Notes
Full package lint still reports existing repo-wide CRLF/Prettier issues in unrelated files, so this PR keeps changes scoped to the indexer implementation.