### PR TITLE
feat: add SDK proof readiness checker

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -108,6 +108,9 @@ export * from "./clients";
 // ── Environment Sanity Checker ──────────────────────────────────────────────
 export * from "./sanity";
 
+// ── Proof Readiness Checker ─────────────────────────────────────────────────
+export * from "./proof-readiness";
+
 // ── Transaction Simulation ──────────────────────────────────────────────────
 export * from "./simulation";
 

--- a/packages/core/src/proof-readiness/checker.ts
+++ b/packages/core/src/proof-readiness/checker.ts
@@ -1,0 +1,351 @@
+/**
+ * Proof readiness checker.
+ *
+ * {@link checkProofReadiness} inspects the proof configuration, input (witness),
+ * environment settings, and requested proof mode, returning a structured report
+ * so SDK consumers can confirm a proof *can* be generated before paying the cost
+ * of generating it.
+ *
+ * Security: raw proof input values are never included in any result message.
+ * Only field names, expected/actual types, and shapes are reported.
+ *
+ * @module
+ */
+
+import type { ProofGeneratorConfig } from "../crypto/IProofGenerator";
+import {
+  ProofReadinessCheck,
+  ProofReadinessCheckId,
+  ProofReadinessInput,
+  ProofReadinessOptions,
+  ProofReadinessResult,
+  ExpectedFieldType,
+  RequiredInputField,
+  SUPPORTED_PROOF_MODES,
+} from "./types";
+
+/** Resolves the effective wasm/zkey locations from a proof config. */
+function resolveArtifactLocation(
+  config: ProofGeneratorConfig,
+  kind: "wasm" | "zkey"
+): string | undefined {
+  const source = kind === "wasm" ? config.wasmSource : config.zkeySource;
+  if (source) {
+    return source.type === "local" ? source.path : source.url;
+  }
+  return kind === "wasm" ? config.wasmUrl : config.zkeyUrl;
+}
+
+/** Returns true when a location is a remote HTTP(S) URL. */
+function isRemote(location: string): boolean {
+  return /^https?:\/\//i.test(location);
+}
+
+/**
+ * Lazily loads Node's `fs` module. Returns `undefined` in environments (e.g.
+ * browsers) where it is unavailable so the caller can degrade gracefully.
+ */
+function tryLoadFs(): typeof import("fs") | undefined {
+  try {
+    // eslint-disable-next-line @typescript-eslint/no-require-imports
+    return require("fs") as typeof import("fs");
+  } catch {
+    return undefined;
+  }
+}
+
+/** Determines the runtime type-tag used for required-field validation. */
+function actualType(value: unknown): ExpectedFieldType | "null" | "undefined" {
+  if (value === null) return "null";
+  if (Array.isArray(value)) return "array";
+  const t = typeof value;
+  if (t === "string" || t === "number" || t === "bigint" || t === "boolean" || t === "object") {
+    return t;
+  }
+  return "undefined";
+}
+
+function checkArtifactAvailability(
+  config: ProofGeneratorConfig,
+  checkFiles: boolean
+): ProofReadinessCheck {
+  const id = ProofReadinessCheckId.ARTIFACT_AVAILABILITY;
+  const label = "Circuit artifact availability";
+  const problems: string[] = [];
+
+  for (const kind of ["wasm", "zkey"] as const) {
+    const expectedExt = `.${kind}`;
+    const location = resolveArtifactLocation(config, kind);
+
+    if (!location || location.trim() === "") {
+      problems.push(`${kind} artifact location is not configured`);
+      continue;
+    }
+
+    if (isRemote(location)) {
+      try {
+        new URL(location);
+      } catch {
+        problems.push(`${kind} artifact URL is malformed`);
+      }
+      continue;
+    }
+
+    // Local path. Normalise a possible file:// URI to a filesystem path.
+    let filePath = location;
+    if (filePath.startsWith("file://")) {
+      try {
+        filePath = new URL(filePath).pathname;
+      } catch {
+        problems.push(`${kind} artifact file:// path is malformed`);
+        continue;
+      }
+    }
+
+    if (!filePath.toLowerCase().endsWith(expectedExt)) {
+      problems.push(`${kind} artifact does not have a ${expectedExt} extension`);
+    }
+
+    if (!checkFiles) continue;
+
+    const fs = tryLoadFs();
+    if (!fs) continue; // Cannot verify off-Node; extension/format checks stand.
+
+    try {
+      const stat = fs.statSync(filePath);
+      if (!stat.isFile()) {
+        problems.push(`${kind} artifact path is not a file`);
+      } else if (stat.size === 0) {
+        problems.push(`${kind} artifact file is empty (0 bytes)`);
+      }
+    } catch (err) {
+      const code = (err as NodeJS.ErrnoException | undefined)?.code;
+      if (code === "EACCES") {
+        problems.push(`${kind} artifact file is not readable (permission denied)`);
+      } else {
+        problems.push(`${kind} artifact file was not found`);
+      }
+    }
+  }
+
+  if (problems.length === 0) {
+    return {
+      id,
+      label,
+      status: "pass",
+      message: "Circuit artifacts (.wasm and .zkey) are configured and available.",
+    };
+  }
+
+  return {
+    id,
+    label,
+    status: "fail",
+    message: `Circuit artifacts are not ready: ${problems.join("; ")}.`,
+    remediation:
+      "Compile the circuit and point wasmUrl/zkeyUrl (or wasmSource/zkeySource) " +
+      "at readable, non-empty .wasm and .zkey files, or a valid HTTP(S) URL.",
+  };
+}
+
+function checkInputShape(
+  input: Record<string, unknown> | undefined,
+  requiredFields: ReadonlyArray<RequiredInputField> | undefined
+): ProofReadinessCheck {
+  const id = ProofReadinessCheckId.INPUT_SHAPE;
+  const label = "Proof input shape";
+
+  if (input === undefined || input === null) {
+    return {
+      id,
+      label,
+      status: "fail",
+      message: "No proof input (witness) was provided.",
+      remediation: "Supply the witness object required by the circuit.",
+    };
+  }
+
+  if (typeof input !== "object" || Array.isArray(input)) {
+    return {
+      id,
+      label,
+      status: "fail",
+      message: `Proof input must be an object but was of type "${actualType(input)}".`,
+      remediation: "Provide the witness as a plain object keyed by signal name.",
+    };
+  }
+
+  const missing: string[] = [];
+  const mistyped: string[] = [];
+
+  for (const field of requiredFields ?? []) {
+    const has = Object.prototype.hasOwnProperty.call(input, field.name);
+    const value = has ? input[field.name] : undefined;
+    if (!has || value === undefined || value === null) {
+      missing.push(field.name);
+      continue;
+    }
+    if (field.type) {
+      const got = actualType(value);
+      if (got !== field.type) {
+        // Report names/types only — never the value itself.
+        mistyped.push(`${field.name} (expected ${field.type}, got ${got})`);
+      }
+    }
+  }
+
+  if (missing.length === 0 && mistyped.length === 0) {
+    return {
+      id,
+      label,
+      status: "pass",
+      message: "Proof input contains all required fields with the expected types.",
+    };
+  }
+
+  const parts: string[] = [];
+  if (missing.length > 0) parts.push(`missing field(s): ${missing.join(", ")}`);
+  if (mistyped.length > 0) parts.push(`type mismatch on ${mistyped.join(", ")}`);
+
+  return {
+    id,
+    label,
+    status: "fail",
+    message: `Proof input is invalid — ${parts.join("; ")}.`,
+    remediation:
+      "Populate the listed fields with values of the expected types. " +
+      "Field values are intentionally omitted from this message to avoid leaking secrets.",
+  };
+}
+
+function checkEnvironmentSettings(config: ProofGeneratorConfig): ProofReadinessCheck {
+  const id = ProofReadinessCheckId.ENVIRONMENT_SETTINGS;
+  const label = "Environment & config settings";
+  const problems: string[] = [];
+
+  const wasm = resolveArtifactLocation(config, "wasm");
+  const zkey = resolveArtifactLocation(config, "zkey");
+  if (!wasm && !zkey) {
+    problems.push("no artifact sources or URLs are configured");
+  }
+
+  if (config.maxConcurrency !== undefined) {
+    if (!Number.isInteger(config.maxConcurrency) || config.maxConcurrency < 1) {
+      problems.push("maxConcurrency must be a positive integer");
+    }
+  }
+
+  if (config.artifactCacheTTL !== undefined) {
+    if (typeof config.artifactCacheTTL !== "number" || config.artifactCacheTTL < 0) {
+      problems.push("artifactCacheTTL must be a non-negative number");
+    }
+  }
+
+  const hashPattern = /^[0-9a-f]{64}$/i;
+  if (config.expectedWasmHash !== undefined && !hashPattern.test(config.expectedWasmHash)) {
+    problems.push("expectedWasmHash is not a 64-character hex SHA-256 digest");
+  }
+  if (config.expectedZkeyHash !== undefined && !hashPattern.test(config.expectedZkeyHash)) {
+    problems.push("expectedZkeyHash is not a 64-character hex SHA-256 digest");
+  }
+
+  if (problems.length === 0) {
+    return {
+      id,
+      label,
+      status: "pass",
+      message: "Environment and configuration settings are valid.",
+    };
+  }
+
+  return {
+    id,
+    label,
+    status: "fail",
+    message: `Configuration settings are invalid: ${problems.join("; ")}.`,
+    remediation:
+      "Correct the listed settings. maxConcurrency must be >= 1, artifactCacheTTL " +
+      ">= 0, and expected hashes must be 64-character hex SHA-256 digests.",
+  };
+}
+
+function checkProofMode(
+  mode: string | undefined,
+  supportedModes: ReadonlyArray<string>
+): ProofReadinessCheck {
+  const id = ProofReadinessCheckId.PROOF_MODE;
+  const label = "Proof mode support";
+  const requested = mode ?? supportedModes[0];
+
+  if (supportedModes.includes(requested)) {
+    return {
+      id,
+      label,
+      status: "pass",
+      message: `Proof mode "${requested}" is supported.`,
+    };
+  }
+
+  return {
+    id,
+    label,
+    status: "fail",
+    message:
+      `Proof mode "${requested}" is not supported. ` +
+      `Supported modes: ${supportedModes.join(", ")}.`,
+    remediation: `Set mode to one of: ${supportedModes.join(", ")}.`,
+  };
+}
+
+/**
+ * Checks whether the SDK is ready to generate a zero-knowledge proof.
+ *
+ * Runs four independent checks — artifact availability, proof input shape,
+ * environment/config settings, and proof mode support — and aggregates them
+ * into a single {@link ProofReadinessResult}. The result is `ready` only when
+ * no check fails.
+ *
+ * No network requests are made and no proof input *values* are echoed into the
+ * returned messages, so the result is safe to log.
+ *
+ * @example
+ * ```typescript
+ * const result = checkProofReadiness(
+ *   { proofConfig, input: witness, mode: "groth16" },
+ *   { requiredInputFields: [{ name: "amount", type: "bigint" }] }
+ * );
+ * if (!result.ready) {
+ *   for (const f of result.failures) console.error(f.message, "→", f.remediation);
+ * }
+ * ```
+ *
+ * @param subject - The proof config, input, and requested mode to evaluate.
+ * @param options - Optional overrides for required fields, supported modes, and
+ *                  whether to probe local artifact files.
+ * @returns A structured readiness report.
+ */
+export function checkProofReadiness(
+  subject: ProofReadinessInput,
+  options: ProofReadinessOptions = {}
+): ProofReadinessResult {
+  const supportedModes =
+    options.supportedModes && options.supportedModes.length > 0
+      ? options.supportedModes
+      : SUPPORTED_PROOF_MODES;
+  const checkFiles = options.checkArtifactFiles ?? true;
+
+  const checks: ProofReadinessCheck[] = [
+    checkArtifactAvailability(subject.proofConfig, checkFiles),
+    checkInputShape(subject.input, options.requiredInputFields),
+    checkEnvironmentSettings(subject.proofConfig),
+    checkProofMode(subject.mode, supportedModes),
+  ];
+
+  const failures = checks.filter((c) => c.status === "fail");
+
+  return {
+    ready: failures.length === 0,
+    checks,
+    failures,
+  };
+}

--- a/packages/core/src/proof-readiness/index.ts
+++ b/packages/core/src/proof-readiness/index.ts
@@ -1,0 +1,19 @@
+/**
+ * Proof readiness checker — verifies proof inputs, artifact paths, environment
+ * settings, and supported proof modes before generation.
+ *
+ * @module
+ */
+
+export { checkProofReadiness } from "./checker";
+export { ProofReadinessCheckId, SUPPORTED_PROOF_MODES } from "./types";
+export type {
+  ProofReadinessInput,
+  ProofReadinessOptions,
+  ProofReadinessResult,
+  ProofReadinessCheck,
+  ProofReadinessStatus,
+  RequiredInputField,
+  ExpectedFieldType,
+  SupportedProofMode,
+} from "./types";

--- a/packages/core/src/proof-readiness/types.ts
+++ b/packages/core/src/proof-readiness/types.ts
@@ -1,0 +1,117 @@
+/**
+ * Type definitions for the proof readiness checker.
+ *
+ * The readiness checker verifies that everything required for zero-knowledge
+ * proof generation is in place *before* the expensive `groth16.fullProve` call
+ * runs, so failures surface early with actionable remediation guidance rather
+ * than deep inside snarkjs.
+ *
+ * @module
+ */
+
+import type { ProofGeneratorConfig } from "../crypto/IProofGenerator";
+
+/** Proof modes (snarkjs protocols) the SDK knows how to generate. */
+export const SUPPORTED_PROOF_MODES = ["groth16"] as const;
+
+/** A proof mode string the SDK supports out of the box. */
+export type SupportedProofMode = (typeof SUPPORTED_PROOF_MODES)[number];
+
+/** Stable identifiers for each individual readiness check. */
+export const ProofReadinessCheckId = {
+  /** Circuit artifact paths/URLs are configured and (locally) present. */
+  ARTIFACT_AVAILABILITY: "artifact-availability",
+  /** The proof input (witness) has the required fields with correct types. */
+  INPUT_SHAPE: "input-shape",
+  /** Environment / configuration settings required for generation are sane. */
+  ENVIRONMENT_SETTINGS: "environment-settings",
+  /** The requested proof mode is one the SDK supports. */
+  PROOF_MODE: "proof-mode",
+} as const;
+
+export type ProofReadinessCheckId =
+  (typeof ProofReadinessCheckId)[keyof typeof ProofReadinessCheckId];
+
+/**
+ * Outcome of a single readiness check.
+ *
+ * - `pass` — the check succeeded, nothing to do.
+ * - `warn` — non-blocking; readiness is not affected but the caller should know.
+ * - `fail` — blocking; proof generation is not expected to succeed.
+ */
+export type ProofReadinessStatus = "pass" | "warn" | "fail";
+
+/** The JavaScript-level type a required proof input field is expected to hold. */
+export type ExpectedFieldType = "string" | "number" | "bigint" | "boolean" | "object" | "array";
+
+/** Describes a single required field on the proof input (witness). */
+export interface RequiredInputField {
+  /** The field name expected on the proof input object. */
+  name: string;
+  /**
+   * Optional expected type. When omitted, only presence (not `undefined`/`null`)
+   * is checked.
+   */
+  type?: ExpectedFieldType;
+}
+
+/** Result of one individual readiness check. */
+export interface ProofReadinessCheck {
+  /** Stable identifier — one of {@link ProofReadinessCheckId}. */
+  id: ProofReadinessCheckId;
+  /** Human-readable label for display in logs and UIs. */
+  label: string;
+  /** Outcome of the check. */
+  status: ProofReadinessStatus;
+  /**
+   * Human-readable explanation of the outcome.
+   *
+   * For failures this never contains raw proof input *values* — only field
+   * names, types, and shapes — so secrets are not leaked into logs.
+   */
+  message: string;
+  /** Actionable guidance describing how to fix a `warn`/`fail` outcome. */
+  remediation?: string;
+}
+
+/** Aggregate result returned by {@link checkProofReadiness}. */
+export interface ProofReadinessResult {
+  /** `true` only when no check has a `fail` status. */
+  ready: boolean;
+  /** Every check that was run, in a stable order. */
+  checks: ProofReadinessCheck[];
+  /** Convenience view of the checks whose status is `fail`. */
+  failures: ProofReadinessCheck[];
+}
+
+/** The subject being evaluated for proof readiness. */
+export interface ProofReadinessInput {
+  /** The proof artifact configuration (wasm/zkey sources or URLs). */
+  proofConfig: ProofGeneratorConfig;
+  /**
+   * The proof input (witness) that will be fed to the prover. Values are never
+   * echoed into result messages — only names/types are reported.
+   */
+  input?: Record<string, unknown>;
+  /** The requested proof mode. Defaults to `"groth16"` when omitted. */
+  mode?: string;
+}
+
+/** Options controlling which checks run and what they consider valid. */
+export interface ProofReadinessOptions {
+  /**
+   * Fields the proof input must contain. When omitted, the input-shape check
+   * only verifies that an input object was supplied.
+   */
+  requiredInputFields?: ReadonlyArray<RequiredInputField>;
+  /**
+   * Proof modes to accept. Defaults to {@link SUPPORTED_PROOF_MODES}.
+   */
+  supportedModes?: ReadonlyArray<string>;
+  /**
+   * Whether to probe the local filesystem for artifacts configured as local
+   * paths. Defaults to `true`. Remote (HTTP) artifacts are only format-checked;
+   * no network request is made.
+   */
+  checkArtifactFiles?: boolean;
+}

--- a/packages/core/tests/proof-readiness.test.ts
+++ b/packages/core/tests/proof-readiness.test.ts
@@ -1,0 +1,264 @@
+import * as fs from "fs";
+import * as path from "path";
+import * as os from "os";
+import { checkProofReadiness, SUPPORTED_PROOF_MODES } from "../src/proof-readiness";
+import type { ProofGeneratorConfig } from "../src/crypto/IProofGenerator";
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+let tempDirs: string[] = [];
+
+function makeTempDir(): string {
+  const dir = fs.mkdtempSync(path.join(os.tmpdir(), "zk-readiness-test-"));
+  tempDirs.push(dir);
+  return dir;
+}
+
+/** Writes valid, non-empty .wasm and .zkey files and returns their paths. */
+function writeValidArtifacts(): { wasmPath: string; zkeyPath: string } {
+  const dir = makeTempDir();
+  const wasmPath = path.join(dir, "payroll.wasm");
+  const zkeyPath = path.join(dir, "payroll.zkey");
+  fs.writeFileSync(wasmPath, Buffer.alloc(128, 0xab));
+  fs.writeFileSync(zkeyPath, Buffer.alloc(256, 0xcd));
+  return { wasmPath, zkeyPath };
+}
+
+function localConfig(): ProofGeneratorConfig {
+  const { wasmPath, zkeyPath } = writeValidArtifacts();
+  return { wasmUrl: wasmPath, zkeyUrl: zkeyPath };
+}
+
+afterAll(() => {
+  for (const dir of tempDirs) {
+    fs.rmSync(dir, { recursive: true, force: true });
+  }
+  tempDirs = [];
+});
+
+// ── Tests ──────────────────────────────────────────────────────────────────
+
+describe("checkProofReadiness", () => {
+  describe("fully-ready state", () => {
+    it("reports ready when artifacts, input, config, and mode are all valid", () => {
+      const result = checkProofReadiness(
+        {
+          proofConfig: localConfig(),
+          input: { amount: 1000n, recipient: "G...", nullifier: "abc" },
+          mode: "groth16",
+        },
+        {
+          requiredInputFields: [
+            { name: "amount", type: "bigint" },
+            { name: "recipient", type: "string" },
+          ],
+        }
+      );
+
+      expect(result.ready).toBe(true);
+      expect(result.failures).toHaveLength(0);
+      expect(result.checks).toHaveLength(4);
+      expect(result.checks.every((c) => c.status === "pass")).toBe(true);
+    });
+
+    it("accepts remote HTTP(S) artifact URLs without hitting the network", () => {
+      const result = checkProofReadiness({
+        proofConfig: {
+          wasmUrl: "https://cdn.example.com/payroll.wasm",
+          zkeyUrl: "https://cdn.example.com/payroll.zkey",
+        },
+        input: {},
+      });
+
+      const artifact = result.checks.find((c) => c.id === "artifact-availability");
+      expect(artifact?.status).toBe("pass");
+    });
+
+    it("defaults the proof mode to groth16 when none is supplied", () => {
+      const result = checkProofReadiness({ proofConfig: localConfig(), input: {} });
+      const mode = result.checks.find((c) => c.id === "proof-mode");
+      expect(mode?.status).toBe("pass");
+      expect(mode?.message).toContain(SUPPORTED_PROOF_MODES[0]);
+    });
+  });
+
+  describe("missing artifacts", () => {
+    it("fails when a local artifact file does not exist", () => {
+      const dir = makeTempDir();
+      const result = checkProofReadiness({
+        proofConfig: {
+          wasmUrl: path.join(dir, "does-not-exist.wasm"),
+          zkeyUrl: path.join(dir, "missing.zkey"),
+        },
+        input: {},
+      });
+
+      expect(result.ready).toBe(false);
+      const artifact = result.failures.find((c) => c.id === "artifact-availability");
+      expect(artifact).toBeDefined();
+      expect(artifact?.message).toContain("was not found");
+      expect(artifact?.remediation).toBeDefined();
+    });
+
+    it("fails when a local artifact file is empty (0 bytes)", () => {
+      const dir = makeTempDir();
+      const wasmPath = path.join(dir, "empty.wasm");
+      const zkeyPath = path.join(dir, "ok.zkey");
+      fs.writeFileSync(wasmPath, Buffer.alloc(0));
+      fs.writeFileSync(zkeyPath, Buffer.alloc(64, 1));
+
+      const result = checkProofReadiness({
+        proofConfig: { wasmUrl: wasmPath, zkeyUrl: zkeyPath },
+        input: {},
+      });
+
+      const artifact = result.checks.find((c) => c.id === "artifact-availability");
+      expect(artifact?.status).toBe("fail");
+      expect(artifact?.message).toContain("empty");
+    });
+
+    it("fails when artifact locations are not configured", () => {
+      const result = checkProofReadiness({
+        proofConfig: { wasmUrl: "", zkeyUrl: "" },
+        input: {},
+      });
+      expect(result.ready).toBe(false);
+      expect(result.failures.some((c) => c.id === "artifact-availability")).toBe(true);
+    });
+
+    it("can skip local filesystem probing via checkArtifactFiles: false", () => {
+      const dir = makeTempDir();
+      const result = checkProofReadiness(
+        {
+          proofConfig: {
+            wasmUrl: path.join(dir, "absent.wasm"),
+            zkeyUrl: path.join(dir, "absent.zkey"),
+          },
+          input: {},
+        },
+        { checkArtifactFiles: false }
+      );
+
+      const artifact = result.checks.find((c) => c.id === "artifact-availability");
+      expect(artifact?.status).toBe("pass");
+    });
+  });
+
+  describe("invalid input", () => {
+    it("fails when no proof input is provided", () => {
+      const result = checkProofReadiness({ proofConfig: localConfig() });
+      const input = result.failures.find((c) => c.id === "input-shape");
+      expect(input?.status).toBe("fail");
+      expect(input?.message).toContain("No proof input");
+    });
+
+    it("fails on missing required fields", () => {
+      const result = checkProofReadiness(
+        { proofConfig: localConfig(), input: { amount: 1000n } },
+        { requiredInputFields: [{ name: "amount" }, { name: "nullifier" }] }
+      );
+      const input = result.failures.find((c) => c.id === "input-shape");
+      expect(input?.status).toBe("fail");
+      expect(input?.message).toContain("nullifier");
+      expect(input?.message).not.toContain("amount, "); // amount was present
+    });
+
+    it("fails on type mismatch and reports expected/actual types only", () => {
+      const result = checkProofReadiness(
+        { proofConfig: localConfig(), input: { amount: "1000" } },
+        { requiredInputFields: [{ name: "amount", type: "bigint" }] }
+      );
+      const input = result.failures.find((c) => c.id === "input-shape");
+      expect(input?.status).toBe("fail");
+      expect(input?.message).toContain("expected bigint, got string");
+    });
+
+    it("fails when the proof input is an array", () => {
+      const result = checkProofReadiness({
+        proofConfig: localConfig(),
+        input: [1, 2, 3] as unknown as Record<string, unknown>,
+      });
+      const input = result.failures.find((c) => c.id === "input-shape");
+      expect(input?.status).toBe("fail");
+      expect(input?.message).toContain("must be an object");
+    });
+  });
+
+  describe("unsupported proof mode", () => {
+    it("fails when the requested mode is not supported", () => {
+      const result = checkProofReadiness({
+        proofConfig: localConfig(),
+        input: {},
+        mode: "plonk",
+      });
+      const mode = result.failures.find((c) => c.id === "proof-mode");
+      expect(mode?.status).toBe("fail");
+      expect(mode?.message).toContain("plonk");
+      expect(mode?.message).toContain("groth16");
+    });
+
+    it("honours a custom supportedModes list", () => {
+      const result = checkProofReadiness(
+        { proofConfig: localConfig(), input: {}, mode: "plonk" },
+        { supportedModes: ["groth16", "plonk"] }
+      );
+      const mode = result.checks.find((c) => c.id === "proof-mode");
+      expect(mode?.status).toBe("pass");
+    });
+  });
+
+  describe("environment settings", () => {
+    it("fails on a non-positive maxConcurrency", () => {
+      const result = checkProofReadiness({
+        proofConfig: { ...localConfig(), maxConcurrency: 0 },
+        input: {},
+      });
+      const env = result.failures.find((c) => c.id === "environment-settings");
+      expect(env?.status).toBe("fail");
+      expect(env?.message).toContain("maxConcurrency");
+    });
+
+    it("fails on a malformed expected hash", () => {
+      const result = checkProofReadiness({
+        proofConfig: { ...localConfig(), expectedWasmHash: "nothex" },
+        input: {},
+      });
+      const env = result.failures.find((c) => c.id === "environment-settings");
+      expect(env?.status).toBe("fail");
+      expect(env?.message).toContain("expectedWasmHash");
+    });
+  });
+
+  describe("security — secret redaction", () => {
+    it("never leaks raw proof input values into any result message", () => {
+      const secret = "SUPER_SECRET_SALARY_9999";
+      const nullifierSecret = "0xdeadbeefsecretnullifier";
+      const result = checkProofReadiness(
+        {
+          proofConfig: localConfig(),
+          input: {
+            amount: secret,
+            recipient: "G_PRIVATE_ADDRESS",
+            nullifier: nullifierSecret,
+          },
+          mode: "groth16",
+        },
+        {
+          requiredInputFields: [
+            { name: "amount", type: "bigint" }, // will mismatch: string vs bigint
+            { name: "missingSecretField" }, // will be reported missing
+          ],
+        }
+      );
+
+      const serialized = JSON.stringify(result);
+      expect(serialized).not.toContain(secret);
+      expect(serialized).not.toContain(nullifierSecret);
+      expect(serialized).not.toContain("G_PRIVATE_ADDRESS");
+
+      // But field names / types are still reported for debuggability.
+      expect(serialized).toContain("amount");
+      expect(serialized).toContain("missingSecretField");
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Adds `checkProofReadiness(...)`, a synchronous, network-free checker that verifies everything required for ZK proof generation is in place **before** the expensive `groth16.fullProve` call runs. It returns a structured `ProofReadinessResult` with an overall `ready` boolean plus a list of individual check results (each with an `id`, `status`, human-readable `message`, and `remediation`).

New module: `packages/core/src/proof-readiness/` (`checker.ts`, `types.ts`, `index.ts`), re-exported from the SDK public entry point (`packages/core/src/index.ts`).

## Checks covered

- **artifact-availability** — resolves wasm/zkey from `wasmSource`/`zkeySource` or `wasmUrl`/`zkeyUrl`; validates remote URLs are well-formed and probes local paths for existence, readability, correct extension, and non-empty content (no network calls; degrades gracefully off-Node).
- **input-shape** — validates the proof input (witness) is a plain object and contains the caller-declared required fields with the expected types.
- **environment-settings** — validates config settings (`maxConcurrency` >= 1, `artifactCacheTTL` >= 0, expected hashes are 64-char hex SHA-256).
- **proof-mode** — verifies the requested mode is supported (defaults to `groth16`; overridable via `supportedModes`).

## Security

Raw/sensitive proof input **values are never included** in any result message — only field names, expected/actual types, and shapes are reported, so results are safe to log. A dedicated test asserts secrets never leak into the serialized result.

## Usage

```typescript
import { checkProofReadiness } from "@zk-payroll/core";

const result = checkProofReadiness(
  { proofConfig, input: witness, mode: "groth16" },
  { requiredInputFields: [{ name: "amount", type: "bigint" }] }
);

if (!result.ready) {
  for (const f of result.failures) console.error(f.message, "->", f.remediation);
}
```

## Tests

Adds `packages/core/tests/proof-readiness.test.ts` (16 tests) covering missing artifacts, empty/unconfigured artifacts, invalid input (missing/mistyped/array), unsupported proof mode, custom supported modes, environment-setting failures, a fully-ready state, and the secret-redaction guarantee. Lint, typecheck, and build all pass.

Closes #260
