### PR TITLE
feat: add audit packages and proof artifact lifecycle (#167 #168)

### DIFF
--- a/docs/audit-packages.md
+++ b/docs/audit-packages.md
@@ -1,0 +1,82 @@
+# Selective-Disclosure Audit Packages
+
+Audit packages let dashboards and authorized reviewers verify payroll integrity
+without receiving every raw private payroll input.
+
+## What is disclosed
+
+An audit package can disclose:
+
+- payroll metadata such as company id, run id, and payroll period
+- commitment references for the allowed scope
+- proof references and public-input hashes
+- verification key references
+- optional proof artifact manifest hash
+- package integrity hash
+
+It should not disclose raw salaries, private keys, view keys, or unrelated
+employees/payroll periods.
+
+## Creating a package
+
+```ts
+import { createSelectiveDisclosureAuditPackage } from "@zk-payroll/core";
+
+const auditPackage = await createSelectiveDisclosureAuditPackage({
+  packageId: "audit-package-2026-07",
+  payroll: {
+    companyId: "company-1",
+    payrollRunId: "run-1",
+    payrollPeriodId: "2026-07",
+    generatedAt: Math.floor(Date.now() / 1000),
+  },
+  disclosureScope: {
+    type: "employee_subset",
+    employeeIds: ["employee-1", "employee-2"],
+    reason: "external audit",
+    expiresAt: 1_900_000_000,
+  },
+  commitments,
+  proofReferences,
+  verificationKeys,
+  artifactManifestHash,
+});
+```
+
+Supported scope types are:
+
+- `employee_subset`
+- `payroll_period`
+- `department`
+- `reason`
+
+## Verifying a package
+
+```ts
+import { verifySelectiveDisclosureAuditPackage } from "@zk-payroll/core";
+
+const result = await verifySelectiveDisclosureAuditPackage(auditPackage);
+
+if (!result.valid) {
+  console.error(result.errors);
+}
+```
+
+Verification checks:
+
+- schema version
+- required payroll metadata
+- disclosure scope shape and expiry
+- proof references
+- verification-key references
+- commitment shape
+- package integrity hash
+
+Tampering with commitments, metadata, or proof references changes the integrity
+hash and causes verification to fail.
+
+## Storage guidance
+
+Store the serialized package, the artifact manifest hash used for verification,
+and the reviewer/audit reason together. Keep raw private payroll inputs outside
+the package unless a future explicit disclosure policy requires them.

--- a/docs/proof-artifacts.md
+++ b/docs/proof-artifacts.md
@@ -1,0 +1,80 @@
+# Proof Artifact Lifecycle Management
+
+Proof artifacts are security-critical dependencies. The SDK now supports a
+versioned manifest format for loading WASM, zkey, and verification-key artifacts
+with integrity and compatibility checks before proof generation begins.
+
+## Manifest format
+
+```ts
+import { ProofArtifactManifest } from "@zk-payroll/core";
+
+const manifest: ProofArtifactManifest = {
+  schemaVersion: "1.0",
+  manifestVersion: "2026.07.30",
+  circuitId: "private-payroll",
+  artifacts: [
+    {
+      kind: "wasm",
+      source: { type: "remote", url: "https://cdn.example/payroll.wasm" },
+      sha256: "...",
+    },
+    {
+      kind: "zkey",
+      source: { type: "remote", url: "https://cdn.example/payroll.zkey" },
+      sha256: "...",
+    },
+    {
+      kind: "verificationKey",
+      source: { type: "remote", url: "https://cdn.example/payroll.vkey.json" },
+      sha256: "...",
+    },
+  ],
+  compatibility: {
+    sdkVersion: "0.1.0",
+    circuitVersion: "payroll-v1",
+    contractVerifierVersion: "verifier-v1",
+    verificationKeyVersion: "vk-v1",
+  },
+  cachePolicy: {
+    mode: "memory",
+    ttlSeconds: 3600,
+    allowStaleFallback: true,
+  },
+};
+```
+
+## Loading artifacts safely
+
+```ts
+import { ProofArtifactLifecycleManager, MemoryProofArtifactCache } from "@zk-payroll/core";
+
+const artifacts = await new ProofArtifactLifecycleManager({
+  cache: new MemoryProofArtifactCache(),
+}).loadArtifacts(manifest, {
+  sdkVersion: "0.1.0",
+  circuitVersion: "payroll-v1",
+  contractVerifierVersion: "verifier-v1",
+  verificationKeyVersion: "vk-v1",
+});
+```
+
+The manager checks:
+
+- manifest schema
+- required artifact kinds
+- SHA-256 hashes
+- optional byte sizes
+- SDK/circuit/verifier/verification-key compatibility
+- cache freshness and stale fallback policy
+
+## Pinning and upgrades
+
+Integrators should pin `manifestVersion`, `circuitVersion`,
+`contractVerifierVersion`, and `verificationKeyVersion` together. Upgrade by
+publishing a new manifest, verifying hashes in CI, then rolling the manifest
+reference to applications after contract verifier compatibility is confirmed.
+
+Avoid silently replacing artifact bytes behind an existing hash or version. A
+changed artifact should always produce a new hash and normally a new manifest
+version.

--- a/examples/proof-artifact-loading/README.md
+++ b/examples/proof-artifact-loading/README.md
@@ -1,0 +1,9 @@
+# Proof Artifact Loading Example
+
+This example shows the expected lifecycle-management flow for integrators:
+
+1. Fetch or read a pinned `ProofArtifactManifest`.
+2. Call `ProofArtifactLifecycleManager.loadArtifacts()`.
+3. Pass verified artifact bytes to proof-generation infrastructure.
+
+See `load.ts` for a minimal TypeScript example.

--- a/examples/proof-artifact-loading/load.ts
+++ b/examples/proof-artifact-loading/load.ts
@@ -1,0 +1,51 @@
+import {
+  MemoryProofArtifactCache,
+  ProofArtifactLifecycleManager,
+  ProofArtifactManifest,
+} from "@zk-payroll/core";
+
+const manifest: ProofArtifactManifest = {
+  schemaVersion: "1.0",
+  manifestVersion: "2026.07.30",
+  circuitId: "private-payroll",
+  artifacts: [
+    {
+      kind: "wasm",
+      source: { type: "remote", url: "https://cdn.example/payroll.wasm" },
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      kind: "zkey",
+      source: { type: "remote", url: "https://cdn.example/payroll.zkey" },
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      kind: "verificationKey",
+      source: { type: "remote", url: "https://cdn.example/payroll.vkey.json" },
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+  ],
+  compatibility: {
+    sdkVersion: "0.1.0",
+    circuitVersion: "payroll-v1",
+    contractVerifierVersion: "verifier-v1",
+    verificationKeyVersion: "vk-v1",
+  },
+};
+
+async function loadArtifacts(): Promise<void> {
+  const manager = new ProofArtifactLifecycleManager({
+    cache: new MemoryProofArtifactCache(),
+  });
+
+  const result = await manager.loadArtifacts(manifest, {
+    sdkVersion: "0.1.0",
+    circuitVersion: "payroll-v1",
+    contractVerifierVersion: "verifier-v1",
+    verificationKeyVersion: "vk-v1",
+  });
+
+  console.log(`Loaded ${result.artifacts.wasm.bytes.byteLength} WASM bytes`);
+}
+
+void loadArtifacts();

--- a/packages/core/src/artifacts/ProofArtifactLifecycleManager.ts
+++ b/packages/core/src/artifacts/ProofArtifactLifecycleManager.ts
@@ -1,0 +1,216 @@
+import { sha256Digest } from "../crypto/hashUtils";
+import { ProofArtifactLifecycleError, ProofArtifactLifecycleErrorCode } from "./errors";
+import {
+  LoadedProofArtifact,
+  LoadedProofArtifactSet,
+  ProofArtifactCache,
+  ProofArtifactCacheEntry,
+  ProofArtifactContentLoader,
+  ProofArtifactDescriptor,
+  ProofArtifactKind,
+  ProofArtifactManifest,
+  ProofArtifactRuntimeCompatibility,
+} from "./types";
+
+export class MemoryProofArtifactCache implements ProofArtifactCache {
+  private readonly entries = new Map<string, ProofArtifactCacheEntry>();
+
+  async get(key: string): Promise<ProofArtifactCacheEntry | undefined> {
+    return this.entries.get(key);
+  }
+
+  async set(key: string, entry: ProofArtifactCacheEntry): Promise<void> {
+    this.entries.set(key, entry);
+  }
+}
+
+export class FetchProofArtifactContentLoader implements ProofArtifactContentLoader {
+  async load(descriptor: ProofArtifactDescriptor): Promise<Uint8Array> {
+    if (descriptor.source.type === "local") {
+      throw new ProofArtifactLifecycleError(
+        "Local artifact loading requires a custom ProofArtifactContentLoader in this runtime.",
+        ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT,
+        { kind: descriptor.kind, path: descriptor.source.path }
+      );
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(descriptor.source.url);
+    } catch (err: unknown) {
+      throw new ProofArtifactLifecycleError(
+        `Failed to fetch ${descriptor.kind} artifact: ${(err as Error).message}`,
+        ProofArtifactLifecycleErrorCode.NETWORK_FETCH_FAILED,
+        { kind: descriptor.kind, url: descriptor.source.url }
+      );
+    }
+
+    if (!response.ok) {
+      throw new ProofArtifactLifecycleError(
+        `Failed to fetch ${descriptor.kind} artifact: HTTP ${response.status}.`,
+        ProofArtifactLifecycleErrorCode.NETWORK_FETCH_FAILED,
+        { kind: descriptor.kind, url: descriptor.source.url, status: response.status }
+      );
+    }
+
+    return new Uint8Array(await response.arrayBuffer());
+  }
+}
+
+export interface ProofArtifactLifecycleManagerOptions {
+  loader?: ProofArtifactContentLoader;
+  cache?: ProofArtifactCache;
+  now?: () => number;
+}
+
+export class ProofArtifactLifecycleManager {
+  private readonly loader: ProofArtifactContentLoader;
+  private readonly cache?: ProofArtifactCache;
+  private readonly now: () => number;
+
+  constructor(options: ProofArtifactLifecycleManagerOptions = {}) {
+    this.loader = options.loader ?? new FetchProofArtifactContentLoader();
+    this.cache = options.cache;
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  async loadArtifacts(
+    manifest: ProofArtifactManifest,
+    runtime: ProofArtifactRuntimeCompatibility
+  ): Promise<LoadedProofArtifactSet> {
+    this.validateManifest(manifest);
+    this.validateCompatibility(manifest, runtime);
+
+    const loaded = await Promise.all(
+      manifest.artifacts.map((descriptor) => this.loadArtifact(manifest, descriptor))
+    );
+
+    return {
+      manifest,
+      artifacts: loaded.reduce(
+        (acc, artifact) => ({
+          ...acc,
+          [artifact.descriptor.kind]: artifact,
+        }),
+        {} as Record<ProofArtifactKind, LoadedProofArtifact>
+      ),
+    };
+  }
+
+  validateManifest(manifest: ProofArtifactManifest): void {
+    if (manifest.schemaVersion !== "1.0" || !manifest.manifestVersion || !manifest.circuitId) {
+      throw new ProofArtifactLifecycleError(
+        "Proof artifact manifest is missing schemaVersion, manifestVersion, or circuitId.",
+        ProofArtifactLifecycleErrorCode.INVALID_MANIFEST,
+        { schemaVersion: manifest.schemaVersion, manifestVersion: manifest.manifestVersion }
+      );
+    }
+
+    const requiredKinds: ProofArtifactKind[] = ["wasm", "zkey", "verificationKey"];
+    const seen = new Set(manifest.artifacts.map((artifact) => artifact.kind));
+    for (const kind of requiredKinds) {
+      if (!seen.has(kind)) {
+        throw new ProofArtifactLifecycleError(
+          `Proof artifact manifest is missing required ${kind} artifact.`,
+          ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT,
+          { kind }
+        );
+      }
+    }
+
+    for (const artifact of manifest.artifacts) {
+      if (!/^[a-f0-9]{64}$/i.test(artifact.sha256)) {
+        throw new ProofArtifactLifecycleError(
+          `Proof artifact ${artifact.kind} has a malformed SHA-256 hash.`,
+          ProofArtifactLifecycleErrorCode.INVALID_MANIFEST,
+          { kind: artifact.kind, sha256: artifact.sha256 }
+        );
+      }
+    }
+  }
+
+  validateCompatibility(
+    manifest: ProofArtifactManifest,
+    runtime: ProofArtifactRuntimeCompatibility
+  ): void {
+    const expected = manifest.compatibility;
+    const checks: Array<keyof ProofArtifactRuntimeCompatibility> = [
+      "sdkVersion",
+      "circuitVersion",
+      "contractVerifierVersion",
+      "verificationKeyVersion",
+    ];
+
+    for (const key of checks) {
+      if (expected[key] !== runtime[key]) {
+        throw new ProofArtifactLifecycleError(
+          `Proof artifact ${key} mismatch: expected ${expected[key]}, got ${runtime[key]}.`,
+          ProofArtifactLifecycleErrorCode.INCOMPATIBLE_VERSION,
+          { field: key, expected: expected[key], actual: runtime[key] }
+        );
+      }
+    }
+  }
+
+  private async loadArtifact(
+    manifest: ProofArtifactManifest,
+    descriptor: ProofArtifactDescriptor
+  ): Promise<LoadedProofArtifact> {
+    const cacheKey = this.cacheKey(manifest, descriptor);
+    const cached = await this.cache?.get(cacheKey);
+    const cachePolicy = manifest.cachePolicy ?? { mode: "disabled" as const };
+
+    if (cached && !this.isExpired(cached, cachePolicy.ttlSeconds)) {
+      await this.verifyHash(cached.bytes, descriptor);
+      return { descriptor, bytes: cached.bytes, loadedFromCache: true, stale: false };
+    }
+
+    try {
+      const bytes = await this.loader.load(descriptor);
+      await this.verifyHash(bytes, descriptor);
+      if (cachePolicy.mode !== "disabled") {
+        await this.cache?.set(cacheKey, { descriptor, bytes, cachedAt: this.now() });
+      }
+      return { descriptor, bytes, loadedFromCache: false, stale: false };
+    } catch (err: unknown) {
+      if (cached && cachePolicy.allowStaleFallback) {
+        await this.verifyHash(cached.bytes, descriptor);
+        return { descriptor, bytes: cached.bytes, loadedFromCache: true, stale: true };
+      }
+      throw err;
+    }
+  }
+
+  private async verifyHash(bytes: Uint8Array, descriptor: ProofArtifactDescriptor): Promise<void> {
+    const actual = await sha256Digest(bytes);
+    if (actual !== descriptor.sha256.toLowerCase()) {
+      throw new ProofArtifactLifecycleError(
+        `SHA-256 mismatch for ${descriptor.kind} artifact.`,
+        ProofArtifactLifecycleErrorCode.HASH_MISMATCH,
+        { kind: descriptor.kind, expected: descriptor.sha256, actual }
+      );
+    }
+
+    if (descriptor.sizeBytes !== undefined && descriptor.sizeBytes !== bytes.byteLength) {
+      throw new ProofArtifactLifecycleError(
+        `Size mismatch for ${descriptor.kind} artifact.`,
+        ProofArtifactLifecycleErrorCode.HASH_MISMATCH,
+        { kind: descriptor.kind, expected: descriptor.sizeBytes, actual: bytes.byteLength }
+      );
+    }
+  }
+
+  private isExpired(entry: ProofArtifactCacheEntry, ttlSeconds?: number): boolean {
+    return ttlSeconds !== undefined && entry.cachedAt + ttlSeconds <= this.now();
+  }
+
+  private cacheKey(manifest: ProofArtifactManifest, descriptor: ProofArtifactDescriptor): string {
+    return [
+      "proof-artifact",
+      manifest.circuitId,
+      manifest.manifestVersion,
+      descriptor.kind,
+      descriptor.sha256,
+    ].join(":");
+  }
+}

--- a/packages/core/src/artifacts/errors.ts
+++ b/packages/core/src/artifacts/errors.ts
@@ -1,0 +1,24 @@
+import { ZkPayrollError } from "../errors";
+
+export const ProofArtifactLifecycleErrorCode = {
+  INVALID_MANIFEST: "PROOF_ARTIFACT_INVALID_MANIFEST",
+  MISSING_ARTIFACT: "PROOF_ARTIFACT_MISSING",
+  HASH_MISMATCH: "PROOF_ARTIFACT_HASH_MISMATCH",
+  INCOMPATIBLE_VERSION: "PROOF_ARTIFACT_INCOMPATIBLE_VERSION",
+  UNSUPPORTED_CACHE_STATE: "PROOF_ARTIFACT_UNSUPPORTED_CACHE_STATE",
+  NETWORK_FETCH_FAILED: "PROOF_ARTIFACT_NETWORK_FETCH_FAILED",
+} as const;
+
+export type ProofArtifactLifecycleErrorCode =
+  (typeof ProofArtifactLifecycleErrorCode)[keyof typeof ProofArtifactLifecycleErrorCode];
+
+export class ProofArtifactLifecycleError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: ProofArtifactLifecycleErrorCode,
+    context?: Record<string, unknown>
+  ) {
+    super(message, code, context);
+    this.name = "ProofArtifactLifecycleError";
+  }
+}

--- a/packages/core/src/artifacts/index.ts
+++ b/packages/core/src/artifacts/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./errors";
+export * from "./ProofArtifactLifecycleManager";

--- a/packages/core/src/artifacts/types.ts
+++ b/packages/core/src/artifacts/types.ts
@@ -1,0 +1,69 @@
+import { ArtifactSource } from "../crypto/IArtifactResolver";
+
+export type ProofArtifactKind = "wasm" | "zkey" | "verificationKey";
+
+export type ProofArtifactCacheMode = "disabled" | "memory" | "persistent";
+
+export interface ProofArtifactDescriptor {
+  kind: ProofArtifactKind;
+  source: ArtifactSource;
+  sha256: string;
+  sizeBytes?: number;
+}
+
+export interface ProofArtifactCompatibility {
+  sdkVersion: string;
+  circuitVersion: string;
+  contractVerifierVersion: string;
+  verificationKeyVersion: string;
+}
+
+export interface ProofArtifactCachePolicy {
+  mode: ProofArtifactCacheMode;
+  ttlSeconds?: number;
+  allowStaleFallback?: boolean;
+}
+
+export interface ProofArtifactManifest {
+  schemaVersion: "1.0";
+  manifestVersion: string;
+  circuitId: string;
+  artifacts: ProofArtifactDescriptor[];
+  compatibility: ProofArtifactCompatibility;
+  cachePolicy?: ProofArtifactCachePolicy;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProofArtifactRuntimeCompatibility {
+  sdkVersion: string;
+  circuitVersion: string;
+  contractVerifierVersion: string;
+  verificationKeyVersion: string;
+}
+
+export interface LoadedProofArtifact {
+  descriptor: ProofArtifactDescriptor;
+  bytes: Uint8Array;
+  loadedFromCache: boolean;
+  stale: boolean;
+}
+
+export interface LoadedProofArtifactSet {
+  manifest: ProofArtifactManifest;
+  artifacts: Record<ProofArtifactKind, LoadedProofArtifact>;
+}
+
+export interface ProofArtifactCacheEntry {
+  descriptor: ProofArtifactDescriptor;
+  bytes: Uint8Array;
+  cachedAt: number;
+}
+
+export interface ProofArtifactCache {
+  get(key: string): Promise<ProofArtifactCacheEntry | undefined>;
+  set(key: string, entry: ProofArtifactCacheEntry): Promise<void>;
+}
+
+export interface ProofArtifactContentLoader {
+  load(descriptor: ProofArtifactDescriptor): Promise<Uint8Array>;
+}

--- a/packages/core/src/audit/auditPackage.ts
+++ b/packages/core/src/audit/auditPackage.ts
@@ -1,0 +1,245 @@
+import { sha256Digest } from "../crypto/hashUtils";
+
+export type AuditDisclosureScopeType =
+  "employee_subset" | "payroll_period" | "department" | "reason";
+
+export interface AuditDisclosureScope {
+  type: AuditDisclosureScopeType;
+  employeeIds?: string[];
+  payrollPeriodIds?: string[];
+  departmentIds?: string[];
+  reason?: string;
+  expiresAt?: number;
+}
+
+export interface AuditPayrollMetadata {
+  companyId: string;
+  payrollRunId: string;
+  payrollPeriodId: string;
+  departmentId?: string;
+  generatedAt: number;
+}
+
+export interface AuditCommitmentReference {
+  id: string;
+  employeeId: string;
+  payrollPeriodId: string;
+  departmentId?: string;
+  commitmentHash: string;
+  amountHash?: string;
+}
+
+export interface AuditProofReference {
+  id: string;
+  proofHash: string;
+  verificationKeyId: string;
+  circuitId: string;
+  publicInputHash: string;
+}
+
+export interface AuditVerificationKeyReference {
+  id: string;
+  version: string;
+  hash: string;
+  proofSystem: string;
+}
+
+export interface SelectiveDisclosureAuditPackage {
+  schemaVersion: "1.0";
+  packageId: string;
+  payroll: AuditPayrollMetadata;
+  disclosureScope: AuditDisclosureScope;
+  commitments: AuditCommitmentReference[];
+  proofReferences: AuditProofReference[];
+  verificationKeys: AuditVerificationKeyReference[];
+  artifactManifestHash?: string;
+  integrityHash: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateAuditPackageInput {
+  packageId: string;
+  payroll: AuditPayrollMetadata;
+  disclosureScope: AuditDisclosureScope;
+  commitments: AuditCommitmentReference[];
+  proofReferences: AuditProofReference[];
+  verificationKeys: AuditVerificationKeyReference[];
+  artifactManifestHash?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditPackageVerificationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export async function createSelectiveDisclosureAuditPackage(
+  input: CreateAuditPackageInput
+): Promise<SelectiveDisclosureAuditPackage> {
+  const scopedCommitments = applyDisclosureScope(input.commitments, input.disclosureScope);
+  const auditPackage: Omit<SelectiveDisclosureAuditPackage, "integrityHash"> = {
+    schemaVersion: "1.0",
+    packageId: input.packageId,
+    payroll: input.payroll,
+    disclosureScope: input.disclosureScope,
+    commitments: scopedCommitments,
+    proofReferences: input.proofReferences,
+    verificationKeys: input.verificationKeys,
+    artifactManifestHash: input.artifactManifestHash,
+    metadata: input.metadata,
+  };
+
+  const errors = validateAuditPackageShape({ ...auditPackage, integrityHash: "" }, true);
+  if (errors.length > 0) {
+    throw new Error(`Invalid audit package input: ${errors.join("; ")}`);
+  }
+
+  return {
+    ...auditPackage,
+    integrityHash: await calculateAuditPackageIntegrityHash(auditPackage),
+  };
+}
+
+export async function verifySelectiveDisclosureAuditPackage(
+  auditPackage: SelectiveDisclosureAuditPackage,
+  now: number = Math.floor(Date.now() / 1000)
+): Promise<AuditPackageVerificationResult> {
+  const errors = validateAuditPackageShape(auditPackage, false, now);
+  const expectedHash = await calculateAuditPackageIntegrityHash({
+    ...auditPackage,
+    integrityHash: undefined,
+  });
+
+  if (expectedHash !== auditPackage.integrityHash) {
+    errors.push("Audit package integrity hash does not match package content.");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function serializeAuditPackage(auditPackage: SelectiveDisclosureAuditPackage): string {
+  return stableStringify(auditPackage);
+}
+
+export function deserializeAuditPackage(serialized: string): SelectiveDisclosureAuditPackage {
+  const parsed = JSON.parse(serialized) as SelectiveDisclosureAuditPackage;
+  if (parsed.schemaVersion !== "1.0") {
+    throw new Error(`Unsupported audit package schema version: ${parsed.schemaVersion}`);
+  }
+  return parsed;
+}
+
+export function applyDisclosureScope(
+  commitments: AuditCommitmentReference[],
+  scope: AuditDisclosureScope
+): AuditCommitmentReference[] {
+  if (scope.type === "employee_subset" && scope.employeeIds) {
+    const allowed = new Set(scope.employeeIds);
+    return commitments.filter((commitment) => allowed.has(commitment.employeeId));
+  }
+
+  if (scope.type === "payroll_period" && scope.payrollPeriodIds) {
+    const allowed = new Set(scope.payrollPeriodIds);
+    return commitments.filter((commitment) => allowed.has(commitment.payrollPeriodId));
+  }
+
+  if (scope.type === "department" && scope.departmentIds) {
+    const allowed = new Set(scope.departmentIds);
+    return commitments.filter(
+      (commitment) => commitment.departmentId !== undefined && allowed.has(commitment.departmentId)
+    );
+  }
+
+  return commitments;
+}
+
+export async function calculateAuditPackageIntegrityHash(
+  auditPackage:
+    Omit<SelectiveDisclosureAuditPackage, "integrityHash"> | SelectiveDisclosureAuditPackage
+): Promise<string> {
+  const { integrityHash: _integrityHash, ...hashable } =
+    auditPackage as SelectiveDisclosureAuditPackage;
+  const encoded = new TextEncoder().encode(stableStringify(hashable));
+  return sha256Digest(encoded);
+}
+
+function validateAuditPackageShape(
+  auditPackage: SelectiveDisclosureAuditPackage,
+  allowBlankIntegrityHash: boolean,
+  now: number = Math.floor(Date.now() / 1000)
+): string[] {
+  const errors: string[] = [];
+
+  if (!auditPackage.packageId) errors.push("packageId is required.");
+  if (auditPackage.schemaVersion !== "1.0") errors.push("schemaVersion must be 1.0.");
+  if (!auditPackage.payroll.companyId) errors.push("payroll.companyId is required.");
+  if (!auditPackage.payroll.payrollRunId) errors.push("payroll.payrollRunId is required.");
+  if (!auditPackage.payroll.payrollPeriodId) errors.push("payroll.payrollPeriodId is required.");
+  if (!auditPackage.disclosureScope.type) errors.push("disclosureScope.type is required.");
+  if (!allowBlankIntegrityHash && !auditPackage.integrityHash) {
+    errors.push("integrityHash is required.");
+  }
+
+  if (
+    auditPackage.disclosureScope.expiresAt !== undefined &&
+    auditPackage.disclosureScope.expiresAt <= now
+  ) {
+    errors.push("disclosureScope is expired.");
+  }
+
+  if (!isDisclosureScopeWellFormed(auditPackage.disclosureScope)) {
+    errors.push("disclosureScope is malformed for its type.");
+  }
+
+  const verificationKeyIds = new Set(auditPackage.verificationKeys.map((key) => key.id));
+  for (const proof of auditPackage.proofReferences) {
+    if (!proof.id || !proof.proofHash || !proof.publicInputHash || !proof.circuitId) {
+      errors.push(`proofReference ${proof.id || "<unknown>"} is incomplete.`);
+    }
+    if (!verificationKeyIds.has(proof.verificationKeyId)) {
+      errors.push(`proofReference ${proof.id} references missing verification key.`);
+    }
+  }
+
+  for (const commitment of auditPackage.commitments) {
+    if (!commitment.id || !commitment.employeeId || !commitment.commitmentHash) {
+      errors.push(`commitment ${commitment.id || "<unknown>"} is incomplete.`);
+    }
+  }
+
+  if (auditPackage.proofReferences.length === 0) {
+    errors.push("At least one proof reference is required.");
+  }
+
+  return errors;
+}
+
+function isDisclosureScopeWellFormed(scope: AuditDisclosureScope): boolean {
+  if (scope.type === "employee_subset") return (scope.employeeIds?.length ?? 0) > 0;
+  if (scope.type === "payroll_period") return (scope.payrollPeriodIds?.length ?? 0) > 0;
+  if (scope.type === "department") return (scope.departmentIds?.length ?? 0) > 0;
+  if (scope.type === "reason") return Boolean(scope.reason);
+  return false;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortForStableJson(value));
+}
+
+function sortForStableJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForStableJson);
+  if (value === null || typeof value !== "object") return value;
+
+  return Object.keys(value as Record<string, unknown>)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) {
+        acc[key] = sortForStableJson(item);
+      }
+      return acc;
+    }, {});
+}

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -2,4 +2,5 @@ export * from "./viewKeyHelpers";
 export * from "./eventNormalizer";
 export * from "./auditReceiptSerializer";
 export * from "./auditRedactionHelper";
+export * from "./auditPackage";
 

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,3 +159,6 @@ export * from "./classification";
 
 // Contract State Indexer
 export * from "./indexer";
+
+// Proof Artifact Lifecycle
+export * from "./artifacts";

--- a/packages/core/tests/audit-package.test.ts
+++ b/packages/core/tests/audit-package.test.ts
@@ -1,0 +1,134 @@
+import {
+  createSelectiveDisclosureAuditPackage,
+  deserializeAuditPackage,
+  serializeAuditPackage,
+  verifySelectiveDisclosureAuditPackage,
+  CreateAuditPackageInput,
+} from "../src/audit";
+
+function makeAuditPackageInput(): CreateAuditPackageInput {
+  return {
+    packageId: "audit-package-1",
+    payroll: {
+      companyId: "company-1",
+      payrollRunId: "run-1",
+      payrollPeriodId: "period-2026-07",
+      generatedAt: 1_800_000_000,
+    },
+    disclosureScope: {
+      type: "employee_subset",
+      employeeIds: ["employee-1"],
+      reason: "quarterly audit",
+      expiresAt: 1_900_000_000,
+    },
+    commitments: [
+      {
+        id: "commitment-1",
+        employeeId: "employee-1",
+        payrollPeriodId: "period-2026-07",
+        departmentId: "engineering",
+        commitmentHash: "commitment-hash-1",
+      },
+      {
+        id: "commitment-2",
+        employeeId: "employee-2",
+        payrollPeriodId: "period-2026-07",
+        departmentId: "finance",
+        commitmentHash: "commitment-hash-2",
+      },
+    ],
+    proofReferences: [
+      {
+        id: "proof-1",
+        proofHash: "proof-hash",
+        verificationKeyId: "vk-1",
+        circuitId: "private-payroll",
+        publicInputHash: "public-input-hash",
+      },
+    ],
+    verificationKeys: [
+      {
+        id: "vk-1",
+        version: "vk-v1",
+        hash: "verification-key-hash",
+        proofSystem: "groth16",
+      },
+    ],
+    artifactManifestHash: "artifact-manifest-hash",
+  };
+}
+
+describe("selective disclosure audit packages", () => {
+  it("generates and verifies a versioned selective-disclosure package", async () => {
+    const auditPackage = await createSelectiveDisclosureAuditPackage(makeAuditPackageInput());
+    const verification = await verifySelectiveDisclosureAuditPackage(auditPackage, 1_800_000_001);
+
+    expect(auditPackage.schemaVersion).toBe("1.0");
+    expect(auditPackage.commitments).toHaveLength(1);
+    expect(auditPackage.commitments[0].employeeId).toBe("employee-1");
+    expect(verification.valid).toBe(true);
+  });
+
+  it("detects tampered metadata, commitments, and proof references through integrity hash", async () => {
+    const auditPackage = await createSelectiveDisclosureAuditPackage(makeAuditPackageInput());
+    const tampered = {
+      ...auditPackage,
+      proofReferences: [{ ...auditPackage.proofReferences[0], proofHash: "tampered" }],
+    };
+
+    const verification = await verifySelectiveDisclosureAuditPackage(tampered, 1_800_000_001);
+    expect(verification.valid).toBe(false);
+    expect(verification.errors).toContain(
+      "Audit package integrity hash does not match package content."
+    );
+  });
+
+  it("rejects expired or malformed disclosure scopes", async () => {
+    await expect(
+      createSelectiveDisclosureAuditPackage({
+        ...makeAuditPackageInput(),
+        disclosureScope: {
+          type: "payroll_period",
+          payrollPeriodIds: ["period-2026-07"],
+          expiresAt: 1_700_000_000,
+        },
+      })
+    ).rejects.toThrow("disclosureScope is expired");
+
+    await expect(
+      createSelectiveDisclosureAuditPackage({
+        ...makeAuditPackageInput(),
+        disclosureScope: { type: "employee_subset", employeeIds: [] },
+      })
+    ).rejects.toThrow("disclosureScope is malformed");
+  });
+
+  it("serializes and deserializes schema version 1.0 packages", async () => {
+    const auditPackage = await createSelectiveDisclosureAuditPackage(makeAuditPackageInput());
+    const serialized = serializeAuditPackage(auditPackage);
+    const deserialized = deserializeAuditPackage(serialized);
+
+    expect(deserialized).toEqual(auditPackage);
+  });
+
+  it("rejects unsupported schema versions during deserialization", () => {
+    expect(() =>
+      deserializeAuditPackage(
+        JSON.stringify({
+          ...makeAuditPackageInput(),
+          schemaVersion: "0.9",
+          integrityHash: "hash",
+        })
+      )
+    ).toThrow("Unsupported audit package schema version");
+  });
+
+  it("fails verification when proof references are missing verification keys", async () => {
+    await expect(
+      createSelectiveDisclosureAuditPackage({
+        ...makeAuditPackageInput(),
+        verificationKeys: [],
+      })
+    ).rejects.toThrow("references missing verification key");
+  });
+});

--- a/packages/core/tests/proof-artifact-lifecycle.test.ts
+++ b/packages/core/tests/proof-artifact-lifecycle.test.ts
@@ -1,0 +1,162 @@
+import { sha256Digest } from "../src/crypto/hashUtils";
+import {
+  MemoryProofArtifactCache,
+  ProofArtifactContentLoader,
+  ProofArtifactDescriptor,
+  ProofArtifactLifecycleError,
+  ProofArtifactLifecycleErrorCode,
+  ProofArtifactLifecycleManager,
+  ProofArtifactManifest,
+  ProofArtifactRuntimeCompatibility,
+} from "../src/artifacts";
+
+class FixtureArtifactLoader implements ProofArtifactContentLoader {
+  public fail = false;
+
+  constructor(private readonly fixtures: Record<string, Uint8Array>) {}
+
+  async load(descriptor: ProofArtifactDescriptor): Promise<Uint8Array> {
+    if (this.fail) {
+      throw new ProofArtifactLifecycleError(
+        "offline",
+        ProofArtifactLifecycleErrorCode.NETWORK_FETCH_FAILED
+      );
+    }
+    const key =
+      descriptor.source.type === "remote" ? descriptor.source.url : descriptor.source.path;
+    const bytes = this.fixtures[key];
+    if (!bytes) {
+      throw new ProofArtifactLifecycleError(
+        "missing",
+        ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT
+      );
+    }
+    return bytes;
+  }
+}
+
+const runtime: ProofArtifactRuntimeCompatibility = {
+  sdkVersion: "0.1.0",
+  circuitVersion: "payroll-v1",
+  contractVerifierVersion: "verifier-v1",
+  verificationKeyVersion: "vk-v1",
+};
+
+async function makeManifest(
+  overrides: Partial<ProofArtifactManifest> = {}
+): Promise<ProofArtifactManifest> {
+  const wasm = new TextEncoder().encode("wasm-bytes");
+  const zkey = new TextEncoder().encode("zkey-bytes");
+  const vkey = new TextEncoder().encode("verification-key");
+
+  return {
+    schemaVersion: "1.0",
+    manifestVersion: "2026.07.30",
+    circuitId: "private-payroll",
+    artifacts: [
+      {
+        kind: "wasm",
+        source: { type: "remote", url: "https://cdn.example/payroll.wasm" },
+        sha256: await sha256Digest(wasm),
+        sizeBytes: wasm.byteLength,
+      },
+      {
+        kind: "zkey",
+        source: { type: "remote", url: "https://cdn.example/payroll.zkey" },
+        sha256: await sha256Digest(zkey),
+        sizeBytes: zkey.byteLength,
+      },
+      {
+        kind: "verificationKey",
+        source: { type: "remote", url: "https://cdn.example/payroll.vkey.json" },
+        sha256: await sha256Digest(vkey),
+        sizeBytes: vkey.byteLength,
+      },
+    ],
+    compatibility: runtime,
+    cachePolicy: { mode: "memory", ttlSeconds: 60, allowStaleFallback: true },
+    ...overrides,
+  };
+}
+
+describe("ProofArtifactLifecycleManager", () => {
+  it("loads versioned manifest artifacts and validates hashes", async () => {
+    const manifest = await makeManifest();
+    const loader = new FixtureArtifactLoader({
+      "https://cdn.example/payroll.wasm": new TextEncoder().encode("wasm-bytes"),
+      "https://cdn.example/payroll.zkey": new TextEncoder().encode("zkey-bytes"),
+      "https://cdn.example/payroll.vkey.json": new TextEncoder().encode("verification-key"),
+    });
+
+    const result = await new ProofArtifactLifecycleManager({
+      loader,
+      cache: new MemoryProofArtifactCache(),
+    }).loadArtifacts(manifest, runtime);
+
+    expect(result.artifacts.wasm.bytes.byteLength).toBeGreaterThan(0);
+    expect(result.artifacts.zkey.loadedFromCache).toBe(false);
+    expect(result.artifacts.verificationKey.descriptor.kind).toBe("verificationKey");
+  });
+
+  it("rejects corrupted artifacts by hash", async () => {
+    const manifest = await makeManifest();
+    const loader = new FixtureArtifactLoader({
+      "https://cdn.example/payroll.wasm": new TextEncoder().encode("tampered"),
+      "https://cdn.example/payroll.zkey": new TextEncoder().encode("zkey-bytes"),
+      "https://cdn.example/payroll.vkey.json": new TextEncoder().encode("verification-key"),
+    });
+
+    await expect(
+      new ProofArtifactLifecycleManager({ loader }).loadArtifacts(manifest, runtime)
+    ).rejects.toMatchObject({
+      code: ProofArtifactLifecycleErrorCode.HASH_MISMATCH,
+    });
+  });
+
+  it("rejects incompatible SDK/circuit/verifier/key versions before proof generation", async () => {
+    const manifest = await makeManifest();
+    await expect(
+      new ProofArtifactLifecycleManager().loadArtifacts(manifest, {
+        ...runtime,
+        contractVerifierVersion: "verifier-v2",
+      })
+    ).rejects.toMatchObject({
+      code: ProofArtifactLifecycleErrorCode.INCOMPATIBLE_VERSION,
+    });
+  });
+
+  it("uses stale cache as an offline fallback when policy allows it", async () => {
+    let now = 1_800_000_000;
+    const manifest = await makeManifest({
+      cachePolicy: { mode: "memory", ttlSeconds: 1, allowStaleFallback: true },
+    });
+    const loader = new FixtureArtifactLoader({
+      "https://cdn.example/payroll.wasm": new TextEncoder().encode("wasm-bytes"),
+      "https://cdn.example/payroll.zkey": new TextEncoder().encode("zkey-bytes"),
+      "https://cdn.example/payroll.vkey.json": new TextEncoder().encode("verification-key"),
+    });
+    const manager = new ProofArtifactLifecycleManager({
+      loader,
+      cache: new MemoryProofArtifactCache(),
+      now: () => now,
+    });
+
+    await manager.loadArtifacts(manifest, runtime);
+    now += 2;
+    loader.fail = true;
+
+    const result = await manager.loadArtifacts(manifest, runtime);
+    expect(result.artifacts.wasm.loadedFromCache).toBe(true);
+    expect(result.artifacts.wasm.stale).toBe(true);
+  });
+
+  it("rejects manifests with missing required artifacts", async () => {
+    const manifest = await makeManifest({ artifacts: [] });
+
+    await expect(
+      new ProofArtifactLifecycleManager().loadArtifacts(manifest, runtime)
+    ).rejects.toMatchObject({
+      code: ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT,
+    });
+  });
+});


### PR DESCRIPTION
Closes #167
Closes #168

## Summary
Adds SDK support for selective-disclosure audit packages and proof artifact lifecycle management. This gives auditors a way to verify payroll integrity without exposing unrelated private payroll inputs, while also ensuring proof artifacts are version-pinned, hash-checked, cache-aware, and compatibility-validated before proof generation.

## Changes
- Added selective-disclosure audit package generation and verification.
- Added versioned audit package schema with:
  - payroll metadata
  - disclosure scope
  - commitment references
  - proof references
  - verification key references
  - artifact manifest hash
  - integrity hash
- Added scoped disclosure support for:
  - employee subset
  - payroll period
  - department
  - audit reason
- Added audit package serialization/deserialization with schema version handling.
- Added tamper detection for metadata, commitments, and proof references.
- Added proof artifact lifecycle manager with:
  - versioned manifest format
  - SHA-256 artifact integrity checks
  - SDK/circuit/contract verifier/verification key compatibility validation
  - memory cache policy support
  - stale-cache fallback support
  - structured lifecycle errors
- Added docs for audit packages and proof artifact pinning/upgrades.
- Added proof artifact loading example.

## Testing
- `npm.cmd run test -w packages/core -- audit-package.test.ts proof-artifact-lifecycle.test.ts`
- `npm.cmd run typecheck -w packages/core`
- `npm.cmd run build -w packages/core`
- Scoped ESLint on new/changed files
- `npm.cmd run test -w packages/core`

## Results
- Full core suite passed: `70 test suites`, `1444 tests`
- Targeted tests cover:
  - valid audit package generation and verification
  - tampered package detection
  - expired/malformed disclosure scopes
  - schema-version handling
  - missing verification-key references
  - valid artifact loading
  - corrupted artifact hash mismatch
  - version mismatch rejection
  - stale cache fallback
  - missing required manifest artifacts

## Notes
Benchmark baseline files were regenerated during full test execution and restored before commit to keep this PR scoped to #167 and #168.