### PR TITLE
feat: add selective disclosure audit packages (#167)

### DIFF
--- a/docs/audit-packages.md
+++ b/docs/audit-packages.md
@@ -1,0 +1,82 @@
+# Selective-Disclosure Audit Packages
+
+Audit packages let dashboards and authorized reviewers verify payroll integrity
+without receiving every raw private payroll input.
+
+## What is disclosed
+
+An audit package can disclose:
+
+- payroll metadata such as company id, run id, and payroll period
+- commitment references for the allowed scope
+- proof references and public-input hashes
+- verification key references
+- optional proof artifact manifest hash
+- package integrity hash
+
+It should not disclose raw salaries, private keys, view keys, or unrelated
+employees/payroll periods.
+
+## Creating a package
+
+```ts
+import { createSelectiveDisclosureAuditPackage } from "@zk-payroll/core";
+
+const auditPackage = await createSelectiveDisclosureAuditPackage({
+  packageId: "audit-package-2026-07",
+  payroll: {
+    companyId: "company-1",
+    payrollRunId: "run-1",
+    payrollPeriodId: "2026-07",
+    generatedAt: Math.floor(Date.now() / 1000),
+  },
+  disclosureScope: {
+    type: "employee_subset",
+    employeeIds: ["employee-1", "employee-2"],
+    reason: "external audit",
+    expiresAt: 1_900_000_000,
+  },
+  commitments,
+  proofReferences,
+  verificationKeys,
+  artifactManifestHash,
+});
+```
+
+Supported scope types are:
+
+- `employee_subset`
+- `payroll_period`
+- `department`
+- `reason`
+
+## Verifying a package
+
+```ts
+import { verifySelectiveDisclosureAuditPackage } from "@zk-payroll/core";
+
+const result = await verifySelectiveDisclosureAuditPackage(auditPackage);
+
+if (!result.valid) {
+  console.error(result.errors);
+}
+```
+
+Verification checks:
+
+- schema version
+- required payroll metadata
+- disclosure scope shape and expiry
+- proof references
+- verification-key references
+- commitment shape
+- package integrity hash
+
+Tampering with commitments, metadata, or proof references changes the integrity
+hash and causes verification to fail.
+
+## Storage guidance
+
+Store the serialized package, the artifact manifest hash used for verification,
+and the reviewer/audit reason together. Keep raw private payroll inputs outside
+the package unless a future explicit disclosure policy requires them.

--- a/packages/core/src/audit/auditPackage.ts
+++ b/packages/core/src/audit/auditPackage.ts
@@ -1,0 +1,245 @@
+import { sha256Digest } from "../crypto/hashUtils";
+
+export type AuditDisclosureScopeType =
+  "employee_subset" | "payroll_period" | "department" | "reason";
+
+export interface AuditDisclosureScope {
+  type: AuditDisclosureScopeType;
+  employeeIds?: string[];
+  payrollPeriodIds?: string[];
+  departmentIds?: string[];
+  reason?: string;
+  expiresAt?: number;
+}
+
+export interface AuditPayrollMetadata {
+  companyId: string;
+  payrollRunId: string;
+  payrollPeriodId: string;
+  departmentId?: string;
+  generatedAt: number;
+}
+
+export interface AuditCommitmentReference {
+  id: string;
+  employeeId: string;
+  payrollPeriodId: string;
+  departmentId?: string;
+  commitmentHash: string;
+  amountHash?: string;
+}
+
+export interface AuditProofReference {
+  id: string;
+  proofHash: string;
+  verificationKeyId: string;
+  circuitId: string;
+  publicInputHash: string;
+}
+
+export interface AuditVerificationKeyReference {
+  id: string;
+  version: string;
+  hash: string;
+  proofSystem: string;
+}
+
+export interface SelectiveDisclosureAuditPackage {
+  schemaVersion: "1.0";
+  packageId: string;
+  payroll: AuditPayrollMetadata;
+  disclosureScope: AuditDisclosureScope;
+  commitments: AuditCommitmentReference[];
+  proofReferences: AuditProofReference[];
+  verificationKeys: AuditVerificationKeyReference[];
+  artifactManifestHash?: string;
+  integrityHash: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface CreateAuditPackageInput {
+  packageId: string;
+  payroll: AuditPayrollMetadata;
+  disclosureScope: AuditDisclosureScope;
+  commitments: AuditCommitmentReference[];
+  proofReferences: AuditProofReference[];
+  verificationKeys: AuditVerificationKeyReference[];
+  artifactManifestHash?: string;
+  metadata?: Record<string, unknown>;
+}
+
+export interface AuditPackageVerificationResult {
+  valid: boolean;
+  errors: string[];
+}
+
+export async function createSelectiveDisclosureAuditPackage(
+  input: CreateAuditPackageInput
+): Promise<SelectiveDisclosureAuditPackage> {
+  const scopedCommitments = applyDisclosureScope(input.commitments, input.disclosureScope);
+  const auditPackage: Omit<SelectiveDisclosureAuditPackage, "integrityHash"> = {
+    schemaVersion: "1.0",
+    packageId: input.packageId,
+    payroll: input.payroll,
+    disclosureScope: input.disclosureScope,
+    commitments: scopedCommitments,
+    proofReferences: input.proofReferences,
+    verificationKeys: input.verificationKeys,
+    artifactManifestHash: input.artifactManifestHash,
+    metadata: input.metadata,
+  };
+
+  const errors = validateAuditPackageShape({ ...auditPackage, integrityHash: "" }, true);
+  if (errors.length > 0) {
+    throw new Error(`Invalid audit package input: ${errors.join("; ")}`);
+  }
+
+  return {
+    ...auditPackage,
+    integrityHash: await calculateAuditPackageIntegrityHash(auditPackage),
+  };
+}
+
+export async function verifySelectiveDisclosureAuditPackage(
+  auditPackage: SelectiveDisclosureAuditPackage,
+  now: number = Math.floor(Date.now() / 1000)
+): Promise<AuditPackageVerificationResult> {
+  const errors = validateAuditPackageShape(auditPackage, false, now);
+  const expectedHash = await calculateAuditPackageIntegrityHash({
+    ...auditPackage,
+    integrityHash: undefined,
+  });
+
+  if (expectedHash !== auditPackage.integrityHash) {
+    errors.push("Audit package integrity hash does not match package content.");
+  }
+
+  return {
+    valid: errors.length === 0,
+    errors,
+  };
+}
+
+export function serializeAuditPackage(auditPackage: SelectiveDisclosureAuditPackage): string {
+  return stableStringify(auditPackage);
+}
+
+export function deserializeAuditPackage(serialized: string): SelectiveDisclosureAuditPackage {
+  const parsed = JSON.parse(serialized) as SelectiveDisclosureAuditPackage;
+  if (parsed.schemaVersion !== "1.0") {
+    throw new Error(`Unsupported audit package schema version: ${parsed.schemaVersion}`);
+  }
+  return parsed;
+}
+
+export function applyDisclosureScope(
+  commitments: AuditCommitmentReference[],
+  scope: AuditDisclosureScope
+): AuditCommitmentReference[] {
+  if (scope.type === "employee_subset" && scope.employeeIds) {
+    const allowed = new Set(scope.employeeIds);
+    return commitments.filter((commitment) => allowed.has(commitment.employeeId));
+  }
+
+  if (scope.type === "payroll_period" && scope.payrollPeriodIds) {
+    const allowed = new Set(scope.payrollPeriodIds);
+    return commitments.filter((commitment) => allowed.has(commitment.payrollPeriodId));
+  }
+
+  if (scope.type === "department" && scope.departmentIds) {
+    const allowed = new Set(scope.departmentIds);
+    return commitments.filter(
+      (commitment) => commitment.departmentId !== undefined && allowed.has(commitment.departmentId)
+    );
+  }
+
+  return commitments;
+}
+
+export async function calculateAuditPackageIntegrityHash(
+  auditPackage:
+    Omit<SelectiveDisclosureAuditPackage, "integrityHash"> | SelectiveDisclosureAuditPackage
+): Promise<string> {
+  const { integrityHash: _integrityHash, ...hashable } =
+    auditPackage as SelectiveDisclosureAuditPackage;
+  const encoded = new TextEncoder().encode(stableStringify(hashable));
+  return sha256Digest(encoded);
+}
+
+function validateAuditPackageShape(
+  auditPackage: SelectiveDisclosureAuditPackage,
+  allowBlankIntegrityHash: boolean,
+  now: number = Math.floor(Date.now() / 1000)
+): string[] {
+  const errors: string[] = [];
+
+  if (!auditPackage.packageId) errors.push("packageId is required.");
+  if (auditPackage.schemaVersion !== "1.0") errors.push("schemaVersion must be 1.0.");
+  if (!auditPackage.payroll.companyId) errors.push("payroll.companyId is required.");
+  if (!auditPackage.payroll.payrollRunId) errors.push("payroll.payrollRunId is required.");
+  if (!auditPackage.payroll.payrollPeriodId) errors.push("payroll.payrollPeriodId is required.");
+  if (!auditPackage.disclosureScope.type) errors.push("disclosureScope.type is required.");
+  if (!allowBlankIntegrityHash && !auditPackage.integrityHash) {
+    errors.push("integrityHash is required.");
+  }
+
+  if (
+    auditPackage.disclosureScope.expiresAt !== undefined &&
+    auditPackage.disclosureScope.expiresAt <= now
+  ) {
+    errors.push("disclosureScope is expired.");
+  }
+
+  if (!isDisclosureScopeWellFormed(auditPackage.disclosureScope)) {
+    errors.push("disclosureScope is malformed for its type.");
+  }
+
+  const verificationKeyIds = new Set(auditPackage.verificationKeys.map((key) => key.id));
+  for (const proof of auditPackage.proofReferences) {
+    if (!proof.id || !proof.proofHash || !proof.publicInputHash || !proof.circuitId) {
+      errors.push(`proofReference ${proof.id || "<unknown>"} is incomplete.`);
+    }
+    if (!verificationKeyIds.has(proof.verificationKeyId)) {
+      errors.push(`proofReference ${proof.id} references missing verification key.`);
+    }
+  }
+
+  for (const commitment of auditPackage.commitments) {
+    if (!commitment.id || !commitment.employeeId || !commitment.commitmentHash) {
+      errors.push(`commitment ${commitment.id || "<unknown>"} is incomplete.`);
+    }
+  }
+
+  if (auditPackage.proofReferences.length === 0) {
+    errors.push("At least one proof reference is required.");
+  }
+
+  return errors;
+}
+
+function isDisclosureScopeWellFormed(scope: AuditDisclosureScope): boolean {
+  if (scope.type === "employee_subset") return (scope.employeeIds?.length ?? 0) > 0;
+  if (scope.type === "payroll_period") return (scope.payrollPeriodIds?.length ?? 0) > 0;
+  if (scope.type === "department") return (scope.departmentIds?.length ?? 0) > 0;
+  if (scope.type === "reason") return Boolean(scope.reason);
+  return false;
+}
+
+function stableStringify(value: unknown): string {
+  return JSON.stringify(sortForStableJson(value));
+}
+
+function sortForStableJson(value: unknown): unknown {
+  if (Array.isArray(value)) return value.map(sortForStableJson);
+  if (value === null || typeof value !== "object") return value;
+
+  return Object.keys(value as Record<string, unknown>)
+    .sort()
+    .reduce<Record<string, unknown>>((acc, key) => {
+      const item = (value as Record<string, unknown>)[key];
+      if (item !== undefined) {
+        acc[key] = sortForStableJson(item);
+      }
+      return acc;
+    }, {});
+}

--- a/packages/core/src/audit/index.ts
+++ b/packages/core/src/audit/index.ts
@@ -2,4 +2,5 @@ export * from "./viewKeyHelpers";
 export * from "./eventNormalizer";
 export * from "./auditReceiptSerializer";
 export * from "./auditRedactionHelper";
+export * from "./auditPackage";
 

--- a/packages/core/tests/audit-package.test.ts
+++ b/packages/core/tests/audit-package.test.ts
@@ -1,0 +1,134 @@
+import {
+  createSelectiveDisclosureAuditPackage,
+  deserializeAuditPackage,
+  serializeAuditPackage,
+  verifySelectiveDisclosureAuditPackage,
+  CreateAuditPackageInput,
+} from "../src/audit";
+
+function makeAuditPackageInput(): CreateAuditPackageInput {
+  return {
+    packageId: "audit-package-1",
+    payroll: {
+      companyId: "company-1",
+      payrollRunId: "run-1",
+      payrollPeriodId: "period-2026-07",
+      generatedAt: 1_800_000_000,
+    },
+    disclosureScope: {
+      type: "employee_subset",
+      employeeIds: ["employee-1"],
+      reason: "quarterly audit",
+      expiresAt: 1_900_000_000,
+    },
+    commitments: [
+      {
+        id: "commitment-1",
+        employeeId: "employee-1",
+        payrollPeriodId: "period-2026-07",
+        departmentId: "engineering",
+        commitmentHash: "commitment-hash-1",
+      },
+      {
+        id: "commitment-2",
+        employeeId: "employee-2",
+        payrollPeriodId: "period-2026-07",
+        departmentId: "finance",
+        commitmentHash: "commitment-hash-2",
+      },
+    ],
+    proofReferences: [
+      {
+        id: "proof-1",
+        proofHash: "proof-hash",
+        verificationKeyId: "vk-1",
+        circuitId: "private-payroll",
+        publicInputHash: "public-input-hash",
+      },
+    ],
+    verificationKeys: [
+      {
+        id: "vk-1",
+        version: "vk-v1",
+        hash: "verification-key-hash",
+        proofSystem: "groth16",
+      },
+    ],
+    artifactManifestHash: "artifact-manifest-hash",
+  };
+}
+
+describe("selective disclosure audit packages", () => {
+  it("generates and verifies a versioned selective-disclosure package", async () => {
+    const auditPackage = await createSelectiveDisclosureAuditPackage(makeAuditPackageInput());
+    const verification = await verifySelectiveDisclosureAuditPackage(auditPackage, 1_800_000_001);
+
+    expect(auditPackage.schemaVersion).toBe("1.0");
+    expect(auditPackage.commitments).toHaveLength(1);
+    expect(auditPackage.commitments[0].employeeId).toBe("employee-1");
+    expect(verification.valid).toBe(true);
+  });
+
+  it("detects tampered metadata, commitments, and proof references through integrity hash", async () => {
+    const auditPackage = await createSelectiveDisclosureAuditPackage(makeAuditPackageInput());
+    const tampered = {
+      ...auditPackage,
+      proofReferences: [{ ...auditPackage.proofReferences[0], proofHash: "tampered" }],
+    };
+
+    const verification = await verifySelectiveDisclosureAuditPackage(tampered, 1_800_000_001);
+    expect(verification.valid).toBe(false);
+    expect(verification.errors).toContain(
+      "Audit package integrity hash does not match package content."
+    );
+  });
+
+  it("rejects expired or malformed disclosure scopes", async () => {
+    await expect(
+      createSelectiveDisclosureAuditPackage({
+        ...makeAuditPackageInput(),
+        disclosureScope: {
+          type: "payroll_period",
+          payrollPeriodIds: ["period-2026-07"],
+          expiresAt: 1_700_000_000,
+        },
+      })
+    ).rejects.toThrow("disclosureScope is expired");
+
+    await expect(
+      createSelectiveDisclosureAuditPackage({
+        ...makeAuditPackageInput(),
+        disclosureScope: { type: "employee_subset", employeeIds: [] },
+      })
+    ).rejects.toThrow("disclosureScope is malformed");
+  });
+
+  it("serializes and deserializes schema version 1.0 packages", async () => {
+    const auditPackage = await createSelectiveDisclosureAuditPackage(makeAuditPackageInput());
+    const serialized = serializeAuditPackage(auditPackage);
+    const deserialized = deserializeAuditPackage(serialized);
+
+    expect(deserialized).toEqual(auditPackage);
+  });
+
+  it("rejects unsupported schema versions during deserialization", () => {
+    expect(() =>
+      deserializeAuditPackage(
+        JSON.stringify({
+          ...makeAuditPackageInput(),
+          schemaVersion: "0.9",
+          integrityHash: "hash",
+        })
+      )
+    ).toThrow("Unsupported audit package schema version");
+  });
+
+  it("fails verification when proof references are missing verification keys", async () => {
+    await expect(
+      createSelectiveDisclosureAuditPackage({
+        ...makeAuditPackageInput(),
+        verificationKeys: [],
+      })
+    ).rejects.toThrow("references missing verification key");
+  });
+});


### PR DESCRIPTION
Closes #167

## Summary
Adds selective-disclosure audit package generation and verification so authorized reviewers can verify payroll integrity without exposing every employee salary or unrelated payroll period.

## Changes
- Added a versioned selective-disclosure audit package schema.
- Added package creation with payroll metadata, disclosure scope, commitment references, proof references, verification key references, optional artifact manifest hash, and integrity hash.
- Added scoped disclosure support for employee subsets, payroll periods, departments, and audit reasons.
- Added package verification for schema shape, expired/malformed scopes, proof references, verification-key references, commitment shape, and integrity hash tampering.
- Added stable serialization/deserialization with schema version handling.
- Exported audit package helpers from the SDK audit module.
- Added documentation explaining what is disclosed, what remains private, and how auditors should verify packages.

## Testing
- `npm.cmd run test -w packages/core -- audit-package.test.ts`
- `npm.cmd run typecheck -w packages/core`

## Notes
This PR is scoped to #167 only. Proof artifact lifecycle management is split into a separate PR for #168.
