### PR TITLE
feat: add proof artifact lifecycle management (#168)

### DIFF
--- a/docs/proof-artifacts.md
+++ b/docs/proof-artifacts.md
@@ -1,0 +1,80 @@
+# Proof Artifact Lifecycle Management
+
+Proof artifacts are security-critical dependencies. The SDK now supports a
+versioned manifest format for loading WASM, zkey, and verification-key artifacts
+with integrity and compatibility checks before proof generation begins.
+
+## Manifest format
+
+```ts
+import { ProofArtifactManifest } from "@zk-payroll/core";
+
+const manifest: ProofArtifactManifest = {
+  schemaVersion: "1.0",
+  manifestVersion: "2026.07.30",
+  circuitId: "private-payroll",
+  artifacts: [
+    {
+      kind: "wasm",
+      source: { type: "remote", url: "https://cdn.example/payroll.wasm" },
+      sha256: "...",
+    },
+    {
+      kind: "zkey",
+      source: { type: "remote", url: "https://cdn.example/payroll.zkey" },
+      sha256: "...",
+    },
+    {
+      kind: "verificationKey",
+      source: { type: "remote", url: "https://cdn.example/payroll.vkey.json" },
+      sha256: "...",
+    },
+  ],
+  compatibility: {
+    sdkVersion: "0.1.0",
+    circuitVersion: "payroll-v1",
+    contractVerifierVersion: "verifier-v1",
+    verificationKeyVersion: "vk-v1",
+  },
+  cachePolicy: {
+    mode: "memory",
+    ttlSeconds: 3600,
+    allowStaleFallback: true,
+  },
+};
+```
+
+## Loading artifacts safely
+
+```ts
+import { ProofArtifactLifecycleManager, MemoryProofArtifactCache } from "@zk-payroll/core";
+
+const artifacts = await new ProofArtifactLifecycleManager({
+  cache: new MemoryProofArtifactCache(),
+}).loadArtifacts(manifest, {
+  sdkVersion: "0.1.0",
+  circuitVersion: "payroll-v1",
+  contractVerifierVersion: "verifier-v1",
+  verificationKeyVersion: "vk-v1",
+});
+```
+
+The manager checks:
+
+- manifest schema
+- required artifact kinds
+- SHA-256 hashes
+- optional byte sizes
+- SDK/circuit/verifier/verification-key compatibility
+- cache freshness and stale fallback policy
+
+## Pinning and upgrades
+
+Integrators should pin `manifestVersion`, `circuitVersion`,
+`contractVerifierVersion`, and `verificationKeyVersion` together. Upgrade by
+publishing a new manifest, verifying hashes in CI, then rolling the manifest
+reference to applications after contract verifier compatibility is confirmed.
+
+Avoid silently replacing artifact bytes behind an existing hash or version. A
+changed artifact should always produce a new hash and normally a new manifest
+version.

--- a/examples/proof-artifact-loading/README.md
+++ b/examples/proof-artifact-loading/README.md
@@ -1,0 +1,9 @@
+# Proof Artifact Loading Example
+
+This example shows the expected lifecycle-management flow for integrators:
+
+1. Fetch or read a pinned `ProofArtifactManifest`.
+2. Call `ProofArtifactLifecycleManager.loadArtifacts()`.
+3. Pass verified artifact bytes to proof-generation infrastructure.
+
+See `load.ts` for a minimal TypeScript example.

--- a/examples/proof-artifact-loading/load.ts
+++ b/examples/proof-artifact-loading/load.ts
@@ -1,0 +1,51 @@
+import {
+  MemoryProofArtifactCache,
+  ProofArtifactLifecycleManager,
+  ProofArtifactManifest,
+} from "@zk-payroll/core";
+
+const manifest: ProofArtifactManifest = {
+  schemaVersion: "1.0",
+  manifestVersion: "2026.07.30",
+  circuitId: "private-payroll",
+  artifacts: [
+    {
+      kind: "wasm",
+      source: { type: "remote", url: "https://cdn.example/payroll.wasm" },
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      kind: "zkey",
+      source: { type: "remote", url: "https://cdn.example/payroll.zkey" },
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+    {
+      kind: "verificationKey",
+      source: { type: "remote", url: "https://cdn.example/payroll.vkey.json" },
+      sha256: "0000000000000000000000000000000000000000000000000000000000000000",
+    },
+  ],
+  compatibility: {
+    sdkVersion: "0.1.0",
+    circuitVersion: "payroll-v1",
+    contractVerifierVersion: "verifier-v1",
+    verificationKeyVersion: "vk-v1",
+  },
+};
+
+async function loadArtifacts(): Promise<void> {
+  const manager = new ProofArtifactLifecycleManager({
+    cache: new MemoryProofArtifactCache(),
+  });
+
+  const result = await manager.loadArtifacts(manifest, {
+    sdkVersion: "0.1.0",
+    circuitVersion: "payroll-v1",
+    contractVerifierVersion: "verifier-v1",
+    verificationKeyVersion: "vk-v1",
+  });
+
+  console.log(`Loaded ${result.artifacts.wasm.bytes.byteLength} WASM bytes`);
+}
+
+void loadArtifacts();

--- a/packages/core/src/artifacts/ProofArtifactLifecycleManager.ts
+++ b/packages/core/src/artifacts/ProofArtifactLifecycleManager.ts
@@ -1,0 +1,216 @@
+import { sha256Digest } from "../crypto/hashUtils";
+import { ProofArtifactLifecycleError, ProofArtifactLifecycleErrorCode } from "./errors";
+import {
+  LoadedProofArtifact,
+  LoadedProofArtifactSet,
+  ProofArtifactCache,
+  ProofArtifactCacheEntry,
+  ProofArtifactContentLoader,
+  ProofArtifactDescriptor,
+  ProofArtifactKind,
+  ProofArtifactManifest,
+  ProofArtifactRuntimeCompatibility,
+} from "./types";
+
+export class MemoryProofArtifactCache implements ProofArtifactCache {
+  private readonly entries = new Map<string, ProofArtifactCacheEntry>();
+
+  async get(key: string): Promise<ProofArtifactCacheEntry | undefined> {
+    return this.entries.get(key);
+  }
+
+  async set(key: string, entry: ProofArtifactCacheEntry): Promise<void> {
+    this.entries.set(key, entry);
+  }
+}
+
+export class FetchProofArtifactContentLoader implements ProofArtifactContentLoader {
+  async load(descriptor: ProofArtifactDescriptor): Promise<Uint8Array> {
+    if (descriptor.source.type === "local") {
+      throw new ProofArtifactLifecycleError(
+        "Local artifact loading requires a custom ProofArtifactContentLoader in this runtime.",
+        ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT,
+        { kind: descriptor.kind, path: descriptor.source.path }
+      );
+    }
+
+    let response: Response;
+    try {
+      response = await fetch(descriptor.source.url);
+    } catch (err: unknown) {
+      throw new ProofArtifactLifecycleError(
+        `Failed to fetch ${descriptor.kind} artifact: ${(err as Error).message}`,
+        ProofArtifactLifecycleErrorCode.NETWORK_FETCH_FAILED,
+        { kind: descriptor.kind, url: descriptor.source.url }
+      );
+    }
+
+    if (!response.ok) {
+      throw new ProofArtifactLifecycleError(
+        `Failed to fetch ${descriptor.kind} artifact: HTTP ${response.status}.`,
+        ProofArtifactLifecycleErrorCode.NETWORK_FETCH_FAILED,
+        { kind: descriptor.kind, url: descriptor.source.url, status: response.status }
+      );
+    }
+
+    return new Uint8Array(await response.arrayBuffer());
+  }
+}
+
+export interface ProofArtifactLifecycleManagerOptions {
+  loader?: ProofArtifactContentLoader;
+  cache?: ProofArtifactCache;
+  now?: () => number;
+}
+
+export class ProofArtifactLifecycleManager {
+  private readonly loader: ProofArtifactContentLoader;
+  private readonly cache?: ProofArtifactCache;
+  private readonly now: () => number;
+
+  constructor(options: ProofArtifactLifecycleManagerOptions = {}) {
+    this.loader = options.loader ?? new FetchProofArtifactContentLoader();
+    this.cache = options.cache;
+    this.now = options.now ?? (() => Math.floor(Date.now() / 1000));
+  }
+
+  async loadArtifacts(
+    manifest: ProofArtifactManifest,
+    runtime: ProofArtifactRuntimeCompatibility
+  ): Promise<LoadedProofArtifactSet> {
+    this.validateManifest(manifest);
+    this.validateCompatibility(manifest, runtime);
+
+    const loaded = await Promise.all(
+      manifest.artifacts.map((descriptor) => this.loadArtifact(manifest, descriptor))
+    );
+
+    return {
+      manifest,
+      artifacts: loaded.reduce(
+        (acc, artifact) => ({
+          ...acc,
+          [artifact.descriptor.kind]: artifact,
+        }),
+        {} as Record<ProofArtifactKind, LoadedProofArtifact>
+      ),
+    };
+  }
+
+  validateManifest(manifest: ProofArtifactManifest): void {
+    if (manifest.schemaVersion !== "1.0" || !manifest.manifestVersion || !manifest.circuitId) {
+      throw new ProofArtifactLifecycleError(
+        "Proof artifact manifest is missing schemaVersion, manifestVersion, or circuitId.",
+        ProofArtifactLifecycleErrorCode.INVALID_MANIFEST,
+        { schemaVersion: manifest.schemaVersion, manifestVersion: manifest.manifestVersion }
+      );
+    }
+
+    const requiredKinds: ProofArtifactKind[] = ["wasm", "zkey", "verificationKey"];
+    const seen = new Set(manifest.artifacts.map((artifact) => artifact.kind));
+    for (const kind of requiredKinds) {
+      if (!seen.has(kind)) {
+        throw new ProofArtifactLifecycleError(
+          `Proof artifact manifest is missing required ${kind} artifact.`,
+          ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT,
+          { kind }
+        );
+      }
+    }
+
+    for (const artifact of manifest.artifacts) {
+      if (!/^[a-f0-9]{64}$/i.test(artifact.sha256)) {
+        throw new ProofArtifactLifecycleError(
+          `Proof artifact ${artifact.kind} has a malformed SHA-256 hash.`,
+          ProofArtifactLifecycleErrorCode.INVALID_MANIFEST,
+          { kind: artifact.kind, sha256: artifact.sha256 }
+        );
+      }
+    }
+  }
+
+  validateCompatibility(
+    manifest: ProofArtifactManifest,
+    runtime: ProofArtifactRuntimeCompatibility
+  ): void {
+    const expected = manifest.compatibility;
+    const checks: Array<keyof ProofArtifactRuntimeCompatibility> = [
+      "sdkVersion",
+      "circuitVersion",
+      "contractVerifierVersion",
+      "verificationKeyVersion",
+    ];
+
+    for (const key of checks) {
+      if (expected[key] !== runtime[key]) {
+        throw new ProofArtifactLifecycleError(
+          `Proof artifact ${key} mismatch: expected ${expected[key]}, got ${runtime[key]}.`,
+          ProofArtifactLifecycleErrorCode.INCOMPATIBLE_VERSION,
+          { field: key, expected: expected[key], actual: runtime[key] }
+        );
+      }
+    }
+  }
+
+  private async loadArtifact(
+    manifest: ProofArtifactManifest,
+    descriptor: ProofArtifactDescriptor
+  ): Promise<LoadedProofArtifact> {
+    const cacheKey = this.cacheKey(manifest, descriptor);
+    const cached = await this.cache?.get(cacheKey);
+    const cachePolicy = manifest.cachePolicy ?? { mode: "disabled" as const };
+
+    if (cached && !this.isExpired(cached, cachePolicy.ttlSeconds)) {
+      await this.verifyHash(cached.bytes, descriptor);
+      return { descriptor, bytes: cached.bytes, loadedFromCache: true, stale: false };
+    }
+
+    try {
+      const bytes = await this.loader.load(descriptor);
+      await this.verifyHash(bytes, descriptor);
+      if (cachePolicy.mode !== "disabled") {
+        await this.cache?.set(cacheKey, { descriptor, bytes, cachedAt: this.now() });
+      }
+      return { descriptor, bytes, loadedFromCache: false, stale: false };
+    } catch (err: unknown) {
+      if (cached && cachePolicy.allowStaleFallback) {
+        await this.verifyHash(cached.bytes, descriptor);
+        return { descriptor, bytes: cached.bytes, loadedFromCache: true, stale: true };
+      }
+      throw err;
+    }
+  }
+
+  private async verifyHash(bytes: Uint8Array, descriptor: ProofArtifactDescriptor): Promise<void> {
+    const actual = await sha256Digest(bytes);
+    if (actual !== descriptor.sha256.toLowerCase()) {
+      throw new ProofArtifactLifecycleError(
+        `SHA-256 mismatch for ${descriptor.kind} artifact.`,
+        ProofArtifactLifecycleErrorCode.HASH_MISMATCH,
+        { kind: descriptor.kind, expected: descriptor.sha256, actual }
+      );
+    }
+
+    if (descriptor.sizeBytes !== undefined && descriptor.sizeBytes !== bytes.byteLength) {
+      throw new ProofArtifactLifecycleError(
+        `Size mismatch for ${descriptor.kind} artifact.`,
+        ProofArtifactLifecycleErrorCode.HASH_MISMATCH,
+        { kind: descriptor.kind, expected: descriptor.sizeBytes, actual: bytes.byteLength }
+      );
+    }
+  }
+
+  private isExpired(entry: ProofArtifactCacheEntry, ttlSeconds?: number): boolean {
+    return ttlSeconds !== undefined && entry.cachedAt + ttlSeconds <= this.now();
+  }
+
+  private cacheKey(manifest: ProofArtifactManifest, descriptor: ProofArtifactDescriptor): string {
+    return [
+      "proof-artifact",
+      manifest.circuitId,
+      manifest.manifestVersion,
+      descriptor.kind,
+      descriptor.sha256,
+    ].join(":");
+  }
+}

--- a/packages/core/src/artifacts/errors.ts
+++ b/packages/core/src/artifacts/errors.ts
@@ -1,0 +1,24 @@
+import { ZkPayrollError } from "../errors";
+
+export const ProofArtifactLifecycleErrorCode = {
+  INVALID_MANIFEST: "PROOF_ARTIFACT_INVALID_MANIFEST",
+  MISSING_ARTIFACT: "PROOF_ARTIFACT_MISSING",
+  HASH_MISMATCH: "PROOF_ARTIFACT_HASH_MISMATCH",
+  INCOMPATIBLE_VERSION: "PROOF_ARTIFACT_INCOMPATIBLE_VERSION",
+  UNSUPPORTED_CACHE_STATE: "PROOF_ARTIFACT_UNSUPPORTED_CACHE_STATE",
+  NETWORK_FETCH_FAILED: "PROOF_ARTIFACT_NETWORK_FETCH_FAILED",
+} as const;
+
+export type ProofArtifactLifecycleErrorCode =
+  (typeof ProofArtifactLifecycleErrorCode)[keyof typeof ProofArtifactLifecycleErrorCode];
+
+export class ProofArtifactLifecycleError extends ZkPayrollError {
+  constructor(
+    message: string,
+    code: ProofArtifactLifecycleErrorCode,
+    context?: Record<string, unknown>
+  ) {
+    super(message, code, context);
+    this.name = "ProofArtifactLifecycleError";
+  }
+}

--- a/packages/core/src/artifacts/index.ts
+++ b/packages/core/src/artifacts/index.ts
@@ -1,0 +1,3 @@
+export * from "./types";
+export * from "./errors";
+export * from "./ProofArtifactLifecycleManager";

--- a/packages/core/src/artifacts/types.ts
+++ b/packages/core/src/artifacts/types.ts
@@ -1,0 +1,69 @@
+import { ArtifactSource } from "../crypto/IArtifactResolver";
+
+export type ProofArtifactKind = "wasm" | "zkey" | "verificationKey";
+
+export type ProofArtifactCacheMode = "disabled" | "memory" | "persistent";
+
+export interface ProofArtifactDescriptor {
+  kind: ProofArtifactKind;
+  source: ArtifactSource;
+  sha256: string;
+  sizeBytes?: number;
+}
+
+export interface ProofArtifactCompatibility {
+  sdkVersion: string;
+  circuitVersion: string;
+  contractVerifierVersion: string;
+  verificationKeyVersion: string;
+}
+
+export interface ProofArtifactCachePolicy {
+  mode: ProofArtifactCacheMode;
+  ttlSeconds?: number;
+  allowStaleFallback?: boolean;
+}
+
+export interface ProofArtifactManifest {
+  schemaVersion: "1.0";
+  manifestVersion: string;
+  circuitId: string;
+  artifacts: ProofArtifactDescriptor[];
+  compatibility: ProofArtifactCompatibility;
+  cachePolicy?: ProofArtifactCachePolicy;
+  metadata?: Record<string, unknown>;
+}
+
+export interface ProofArtifactRuntimeCompatibility {
+  sdkVersion: string;
+  circuitVersion: string;
+  contractVerifierVersion: string;
+  verificationKeyVersion: string;
+}
+
+export interface LoadedProofArtifact {
+  descriptor: ProofArtifactDescriptor;
+  bytes: Uint8Array;
+  loadedFromCache: boolean;
+  stale: boolean;
+}
+
+export interface LoadedProofArtifactSet {
+  manifest: ProofArtifactManifest;
+  artifacts: Record<ProofArtifactKind, LoadedProofArtifact>;
+}
+
+export interface ProofArtifactCacheEntry {
+  descriptor: ProofArtifactDescriptor;
+  bytes: Uint8Array;
+  cachedAt: number;
+}
+
+export interface ProofArtifactCache {
+  get(key: string): Promise<ProofArtifactCacheEntry | undefined>;
+  set(key: string, entry: ProofArtifactCacheEntry): Promise<void>;
+}
+
+export interface ProofArtifactContentLoader {
+  load(descriptor: ProofArtifactDescriptor): Promise<Uint8Array>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -159,3 +159,6 @@ export * from "./classification";
 
 // Contract State Indexer
 export * from "./indexer";
+
+// Proof Artifact Lifecycle
+export * from "./artifacts";

--- a/packages/core/tests/proof-artifact-lifecycle.test.ts
+++ b/packages/core/tests/proof-artifact-lifecycle.test.ts
@@ -1,0 +1,162 @@
+import { sha256Digest } from "../src/crypto/hashUtils";
+import {
+  MemoryProofArtifactCache,
+  ProofArtifactContentLoader,
+  ProofArtifactDescriptor,
+  ProofArtifactLifecycleError,
+  ProofArtifactLifecycleErrorCode,
+  ProofArtifactLifecycleManager,
+  ProofArtifactManifest,
+  ProofArtifactRuntimeCompatibility,
+} from "../src/artifacts";
+
+class FixtureArtifactLoader implements ProofArtifactContentLoader {
+  public fail = false;
+
+  constructor(private readonly fixtures: Record<string, Uint8Array>) {}
+
+  async load(descriptor: ProofArtifactDescriptor): Promise<Uint8Array> {
+    if (this.fail) {
+      throw new ProofArtifactLifecycleError(
+        "offline",
+        ProofArtifactLifecycleErrorCode.NETWORK_FETCH_FAILED
+      );
+    }
+    const key =
+      descriptor.source.type === "remote" ? descriptor.source.url : descriptor.source.path;
+    const bytes = this.fixtures[key];
+    if (!bytes) {
+      throw new ProofArtifactLifecycleError(
+        "missing",
+        ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT
+      );
+    }
+    return bytes;
+  }
+}
+
+const runtime: ProofArtifactRuntimeCompatibility = {
+  sdkVersion: "0.1.0",
+  circuitVersion: "payroll-v1",
+  contractVerifierVersion: "verifier-v1",
+  verificationKeyVersion: "vk-v1",
+};
+
+async function makeManifest(
+  overrides: Partial<ProofArtifactManifest> = {}
+): Promise<ProofArtifactManifest> {
+  const wasm = new TextEncoder().encode("wasm-bytes");
+  const zkey = new TextEncoder().encode("zkey-bytes");
+  const vkey = new TextEncoder().encode("verification-key");
+
+  return {
+    schemaVersion: "1.0",
+    manifestVersion: "2026.07.30",
+    circuitId: "private-payroll",
+    artifacts: [
+      {
+        kind: "wasm",
+        source: { type: "remote", url: "https://cdn.example/payroll.wasm" },
+        sha256: await sha256Digest(wasm),
+        sizeBytes: wasm.byteLength,
+      },
+      {
+        kind: "zkey",
+        source: { type: "remote", url: "https://cdn.example/payroll.zkey" },
+        sha256: await sha256Digest(zkey),
+        sizeBytes: zkey.byteLength,
+      },
+      {
+        kind: "verificationKey",
+        source: { type: "remote", url: "https://cdn.example/payroll.vkey.json" },
+        sha256: await sha256Digest(vkey),
+        sizeBytes: vkey.byteLength,
+      },
+    ],
+    compatibility: runtime,
+    cachePolicy: { mode: "memory", ttlSeconds: 60, allowStaleFallback: true },
+    ...overrides,
+  };
+}
+
+describe("ProofArtifactLifecycleManager", () => {
+  it("loads versioned manifest artifacts and validates hashes", async () => {
+    const manifest = await makeManifest();
+    const loader = new FixtureArtifactLoader({
+      "https://cdn.example/payroll.wasm": new TextEncoder().encode("wasm-bytes"),
+      "https://cdn.example/payroll.zkey": new TextEncoder().encode("zkey-bytes"),
+      "https://cdn.example/payroll.vkey.json": new TextEncoder().encode("verification-key"),
+    });
+
+    const result = await new ProofArtifactLifecycleManager({
+      loader,
+      cache: new MemoryProofArtifactCache(),
+    }).loadArtifacts(manifest, runtime);
+
+    expect(result.artifacts.wasm.bytes.byteLength).toBeGreaterThan(0);
+    expect(result.artifacts.zkey.loadedFromCache).toBe(false);
+    expect(result.artifacts.verificationKey.descriptor.kind).toBe("verificationKey");
+  });
+
+  it("rejects corrupted artifacts by hash", async () => {
+    const manifest = await makeManifest();
+    const loader = new FixtureArtifactLoader({
+      "https://cdn.example/payroll.wasm": new TextEncoder().encode("tampered"),
+      "https://cdn.example/payroll.zkey": new TextEncoder().encode("zkey-bytes"),
+      "https://cdn.example/payroll.vkey.json": new TextEncoder().encode("verification-key"),
+    });
+
+    await expect(
+      new ProofArtifactLifecycleManager({ loader }).loadArtifacts(manifest, runtime)
+    ).rejects.toMatchObject({
+      code: ProofArtifactLifecycleErrorCode.HASH_MISMATCH,
+    });
+  });
+
+  it("rejects incompatible SDK/circuit/verifier/key versions before proof generation", async () => {
+    const manifest = await makeManifest();
+    await expect(
+      new ProofArtifactLifecycleManager().loadArtifacts(manifest, {
+        ...runtime,
+        contractVerifierVersion: "verifier-v2",
+      })
+    ).rejects.toMatchObject({
+      code: ProofArtifactLifecycleErrorCode.INCOMPATIBLE_VERSION,
+    });
+  });
+
+  it("uses stale cache as an offline fallback when policy allows it", async () => {
+    let now = 1_800_000_000;
+    const manifest = await makeManifest({
+      cachePolicy: { mode: "memory", ttlSeconds: 1, allowStaleFallback: true },
+    });
+    const loader = new FixtureArtifactLoader({
+      "https://cdn.example/payroll.wasm": new TextEncoder().encode("wasm-bytes"),
+      "https://cdn.example/payroll.zkey": new TextEncoder().encode("zkey-bytes"),
+      "https://cdn.example/payroll.vkey.json": new TextEncoder().encode("verification-key"),
+    });
+    const manager = new ProofArtifactLifecycleManager({
+      loader,
+      cache: new MemoryProofArtifactCache(),
+      now: () => now,
+    });
+
+    await manager.loadArtifacts(manifest, runtime);
+    now += 2;
+    loader.fail = true;
+
+    const result = await manager.loadArtifacts(manifest, runtime);
+    expect(result.artifacts.wasm.loadedFromCache).toBe(true);
+    expect(result.artifacts.wasm.stale).toBe(true);
+  });
+
+  it("rejects manifests with missing required artifacts", async () => {
+    const manifest = await makeManifest({ artifacts: [] });
+
+    await expect(
+      new ProofArtifactLifecycleManager().loadArtifacts(manifest, runtime)
+    ).rejects.toMatchObject({
+      code: ProofArtifactLifecycleErrorCode.MISSING_ARTIFACT,
+    });
+  });
+});


### PR DESCRIPTION
Closes #168

## Summary
Adds proof artifact lifecycle management for version-pinned WASM, zkey, and verification-key artifacts with integrity checks, compatibility validation, cache policy, stale-cache fallback, and structured lifecycle errors.

## Changes
- Added a versioned proof artifact manifest format.
- Added artifact descriptors for WASM, zkey, and verification key artifacts.
- Added SHA-256 integrity checks before artifacts are accepted.
- Added SDK, circuit, contract verifier, and verification-key version compatibility validation.
- Added memory cache support with TTL and stale fallback behavior.
- Added structured lifecycle errors for invalid manifests, missing artifacts, hash mismatches, incompatible versions, unsupported cache states, and network fetch failures.
- Exported artifact lifecycle APIs from the SDK entrypoint.
- Added proof artifact lifecycle documentation and a proof artifact loading example.

## Testing
- `npm.cmd run test -w packages/core -- proof-artifact-lifecycle.test.ts`
- `npm.cmd run typecheck -w packages/core`

## Notes
This PR is scoped to #168 only. Selective-disclosure audit packages are split into a separate PR for #167.
