### PR TITLE
feat: add payroll lifecycle event aggregator

### DIFF
--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -146,6 +146,9 @@ export * from "./audit";
 // ── Webhook Verification ────────────────────────────────────────────────────
 export * from "./webhooks";
 
+// ── Payroll Lifecycle Event Aggregator ──────────────────────────────────────
+export * from "./lifecycle";
+
 // ── Environment Capability Detector ─────────────────────────────────────────
 export * from "./env";
 

--- a/packages/core/src/lifecycle/eventAggregator.ts
+++ b/packages/core/src/lifecycle/eventAggregator.ts
@@ -1,0 +1,199 @@
+/**
+ * Payroll Lifecycle Event Aggregator
+ *
+ * Merges raw payroll, treasury, wallet, and contract events into a single,
+ * time-ordered lifecycle stream. Integrators consume one reliable sequence
+ * for dashboards, notifications, audit views, and reconciliation tools
+ * instead of stitching together several independent event sources.
+ *
+ * ## Usage
+ *
+ * ```ts
+ * import { aggregateLifecycleEvents } from "@zk-payroll/core";
+ *
+ * const stream = aggregateLifecycleEvents([
+ *   payrollEvents,   // source: "payroll"
+ *   treasuryEvents,  // source: "treasury"
+ *   walletEvents,    // source: "wallet"
+ *   contractEvents,  // source: "contract"
+ * ]);
+ *
+ * for (const event of stream) {
+ *   console.log(event.timestamp, event.source, event.type, event.summary);
+ * }
+ * ```
+ */
+
+// ── Source & Raw Event ──────────────────────────────────────────────────────
+
+/** Origin of a raw lifecycle event, prior to aggregation. */
+export type LifecycleEventSource = "payroll" | "treasury" | "wallet" | "contract";
+
+/**
+ * A raw event as produced by one of the upstream systems (payroll engine,
+ * treasury service, wallet adapter, or on-chain contract indexer).
+ */
+export interface RawLifecycleEvent {
+  /** Which system produced this event. */
+  source: LifecycleEventSource;
+  /** Event-specific discriminant, e.g. "payment_executed", "funds_deposited". */
+  type: string;
+  /** Millisecond epoch timestamp of when the event occurred. */
+  timestamp: number;
+  /**
+   * Optional monotonic sequence number from the origin system, used to
+   * break ties when two events share a timestamp (e.g. same ledger).
+   */
+  sequence?: number;
+  /** Stellar public key, user ID, or system identifier that caused the event. */
+  actor?: string;
+  /** Optional human-readable summary; auto-generated when omitted. */
+  summary?: string;
+  /** Arbitrary event-specific payload. */
+  details?: Record<string, unknown>;
+}
+
+// ── Aggregated Lifecycle Event ──────────────────────────────────────────────
+
+/** A single event in the merged, ordered lifecycle stream. */
+export interface LifecycleEvent {
+  /** Unique identifier, stable for the lifetime of the stream. */
+  id: string;
+  /** Millisecond epoch timestamp used for ordering. */
+  timestamp: number;
+  /** Origin system. */
+  source: LifecycleEventSource;
+  /** Event-specific discriminant. */
+  type: string;
+  /** Actor responsible for the event, if known. */
+  actor: string;
+  /** Human-readable summary. */
+  summary: string;
+  /** Event-specific payload, unchanged from the raw event. */
+  details: Record<string, unknown>;
+  /**
+   * Position of this event within the merged stream (0-based, after
+   * ordering). Stable for a given input set.
+   */
+  index: number;
+}
+
+export interface AggregateLifecycleEventsOptions {
+  /** Sort direction by timestamp. Defaults to "asc" (oldest first). */
+  order?: "asc" | "desc";
+  /** Restrict the aggregated stream to these sources. */
+  sources?: LifecycleEventSource[];
+}
+
+// ── Internal Helpers ─────────────────────────────────────────────────────────
+
+let idCounter = 0;
+
+/** Generate a stream-local event ID (stable ordering key, not a UUID). */
+function generateLifecycleEventId(source: LifecycleEventSource, timestamp: number): string {
+  idCounter += 1;
+  return `lc_${source}_${timestamp}_${idCounter}`;
+}
+
+function defaultSummary(event: RawLifecycleEvent): string {
+  const actor = event.actor ? ` (${event.actor})` : "";
+  return `${event.source}.${event.type}${actor}`;
+}
+
+// ── Public API ───────────────────────────────────────────────────────────────
+
+/**
+ * Aggregate raw payroll, treasury, wallet, and contract events into a single
+ * ordered lifecycle stream.
+ *
+ * Accepts either a flat array of raw events, or an array of arrays (one per
+ * source) for convenience when callers already have events grouped by
+ * origin. Events are sorted by `timestamp`, then by `sequence` (if present),
+ * then by their original position, so ties resolve deterministically.
+ *
+ * @param rawEvents - Raw events, flat or grouped by source.
+ * @param options   - Ordering and source-filtering options.
+ * @returns         A single, time-ordered `LifecycleEvent[]`.
+ */
+export function aggregateLifecycleEvents(
+  rawEvents: RawLifecycleEvent[] | RawLifecycleEvent[][],
+  options: AggregateLifecycleEventsOptions = {}
+): LifecycleEvent[] {
+  const flat: RawLifecycleEvent[] = Array.isArray(rawEvents[0])
+    ? (rawEvents as RawLifecycleEvent[][]).flat()
+    : (rawEvents as RawLifecycleEvent[]);
+
+  const order = options.order ?? "asc";
+  const sourceFilter = options.sources ? new Set(options.sources) : undefined;
+
+  const filtered = sourceFilter ? flat.filter((e) => sourceFilter.has(e.source)) : flat.slice();
+
+  // Preserve original position for stable tie-breaking.
+  const withPosition = filtered.map((event, position) => ({ event, position }));
+
+  withPosition.sort((a, b) => {
+    if (a.event.timestamp !== b.event.timestamp) {
+      return order === "asc"
+        ? a.event.timestamp - b.event.timestamp
+        : b.event.timestamp - a.event.timestamp;
+    }
+    const aSeq = a.event.sequence ?? a.position;
+    const bSeq = b.event.sequence ?? b.position;
+    if (aSeq !== bSeq) {
+      return order === "asc" ? aSeq - bSeq : bSeq - aSeq;
+    }
+    return a.position - b.position;
+  });
+
+  return withPosition.map(({ event }, index) => ({
+    id: generateLifecycleEventId(event.source, event.timestamp),
+    timestamp: event.timestamp,
+    source: event.source,
+    type: event.type,
+    actor: event.actor ?? "",
+    summary: event.summary ?? defaultSummary(event),
+    details: event.details ?? {},
+    index,
+  }));
+}
+
+/**
+ * Group an already-aggregated lifecycle stream by source.
+ *
+ * @param events - A lifecycle stream, typically from `aggregateLifecycleEvents`.
+ * @returns      Events bucketed by their originating source.
+ */
+export function groupLifecycleEventsBySource(
+  events: LifecycleEvent[]
+): Record<LifecycleEventSource, LifecycleEvent[]> {
+  const grouped: Record<LifecycleEventSource, LifecycleEvent[]> = {
+    payroll: [],
+    treasury: [],
+    wallet: [],
+    contract: [],
+  };
+  for (const event of events) {
+    grouped[event.source].push(event);
+  }
+  return grouped;
+}
+
+/**
+ * Filter a lifecycle stream by source, type, and/or actor. Pure — does not
+ * mutate the input.
+ *
+ * @param events - A lifecycle stream to filter.
+ * @param filter - Criteria that must all match.
+ * @returns      The matching subset, in original order.
+ */
+export function filterLifecycleEvents(
+  events: LifecycleEvent[],
+  filter: { source?: LifecycleEventSource; type?: string; actor?: string }
+): LifecycleEvent[] {
+  return events.filter((event) => {
+    if (filter.source && event.source !== filter.source) return false;
+    if (filter.type && event.type !== filter.type) return false;
+    if (filter.actor && event.actor !== filter.actor) return false;
+    return true;
+  });
+}

--- a/packages/core/src/lifecycle/index.ts
+++ b/packages/core/src/lifecycle/index.ts
@@ -1,0 +1,1 @@
+export * from "./eventAggregator";

--- a/packages/core/tests/lifecycle-event-aggregator.test.ts
+++ b/packages/core/tests/lifecycle-event-aggregator.test.ts
@@ -1,0 +1,115 @@
+/**
+ * Tests for the payroll lifecycle event aggregator.
+ */
+
+import {
+  aggregateLifecycleEvents,
+  groupLifecycleEventsBySource,
+  filterLifecycleEvents,
+} from "../src/lifecycle/eventAggregator";
+import type { RawLifecycleEvent } from "../src/lifecycle/eventAggregator";
+
+const payrollEvent: RawLifecycleEvent = {
+  source: "payroll",
+  type: "cycle_started",
+  timestamp: 1000,
+  actor: "GEMPLOYER",
+};
+
+const treasuryEvent: RawLifecycleEvent = {
+  source: "treasury",
+  type: "funds_deposited",
+  timestamp: 500,
+  actor: "GTREASURY",
+  details: { amount: "1000" },
+};
+
+const walletEvent: RawLifecycleEvent = {
+  source: "wallet",
+  type: "signature_requested",
+  timestamp: 750,
+  sequence: 1,
+};
+
+const contractEvent: RawLifecycleEvent = {
+  source: "contract",
+  type: "payment_executed",
+  timestamp: 750,
+  sequence: 0,
+};
+
+describe("aggregateLifecycleEvents", () => {
+  it("merges events from multiple sources into ascending timestamp order", () => {
+    const stream = aggregateLifecycleEvents([
+      [payrollEvent],
+      [treasuryEvent],
+      [walletEvent],
+      [contractEvent],
+    ]);
+
+    expect(stream.map((e) => e.source)).toEqual(["treasury", "contract", "wallet", "payroll"]);
+    expect(stream.map((e) => e.timestamp)).toEqual([500, 750, 750, 1000]);
+    expect(stream.map((e) => e.index)).toEqual([0, 1, 2, 3]);
+  });
+
+  it("breaks timestamp ties using sequence when present", () => {
+    const stream = aggregateLifecycleEvents([contractEvent, walletEvent]);
+    expect(stream.map((e) => e.source)).toEqual(["contract", "wallet"]);
+  });
+
+  it("supports descending order", () => {
+    const stream = aggregateLifecycleEvents([payrollEvent, treasuryEvent], { order: "desc" });
+    expect(stream.map((e) => e.source)).toEqual(["payroll", "treasury"]);
+  });
+
+  it("filters to requested sources only", () => {
+    const stream = aggregateLifecycleEvents(
+      [payrollEvent, treasuryEvent, walletEvent, contractEvent],
+      { sources: ["payroll", "treasury"] }
+    );
+    expect(stream.every((e) => e.source === "payroll" || e.source === "treasury")).toBe(true);
+    expect(stream).toHaveLength(2);
+  });
+
+  it("accepts a flat array as well as grouped arrays", () => {
+    const flat = aggregateLifecycleEvents([payrollEvent, treasuryEvent]);
+    expect(flat.map((e) => e.source)).toEqual(["treasury", "payroll"]);
+  });
+
+  it("generates a default summary when none is provided", () => {
+    const [event] = aggregateLifecycleEvents([payrollEvent]);
+    expect(event.summary).toBe("payroll.cycle_started (GEMPLOYER)");
+  });
+
+  it("assigns unique, stable ids", () => {
+    const stream = aggregateLifecycleEvents([payrollEvent, treasuryEvent]);
+    const ids = new Set(stream.map((e) => e.id));
+    expect(ids.size).toBe(stream.length);
+  });
+});
+
+describe("groupLifecycleEventsBySource", () => {
+  it("buckets a stream back out by source", () => {
+    const stream = aggregateLifecycleEvents([
+      payrollEvent,
+      treasuryEvent,
+      walletEvent,
+      contractEvent,
+    ]);
+    const grouped = groupLifecycleEventsBySource(stream);
+    expect(grouped.payroll).toHaveLength(1);
+    expect(grouped.treasury).toHaveLength(1);
+    expect(grouped.wallet).toHaveLength(1);
+    expect(grouped.contract).toHaveLength(1);
+  });
+});
+
+describe("filterLifecycleEvents", () => {
+  it("filters by source, type, and actor", () => {
+    const stream = aggregateLifecycleEvents([payrollEvent, treasuryEvent]);
+    expect(filterLifecycleEvents(stream, { source: "treasury" })).toHaveLength(1);
+    expect(filterLifecycleEvents(stream, { type: "cycle_started" })).toHaveLength(1);
+    expect(filterLifecycleEvents(stream, { actor: "GTREASURY" })).toHaveLength(1);
+    expect(filterLifecycleEvents(stream, { actor: "nope" })).toHaveLength(0);
+  });
+});


### PR DESCRIPTION
## Summary
Adds a payroll lifecycle event aggregator that merges raw payroll, treasury, wallet, and contract events into a single, time-ordered lifecycle stream.

- `aggregateLifecycleEvents()` accepts flat or per-source arrays of raw events and returns a merged `LifecycleEvent[]`, sorted by `timestamp`, then `sequence`, then original position for deterministic tie-breaking.
- `groupLifecycleEventsBySource()` buckets an aggregated stream back out by origin (`payroll` | `treasury` | `wallet` | `contract`).
- `filterLifecycleEvents()` filters a stream by source, type, and/or actor.
- Exported from `@zk-payroll/core` via `packages/core/src/lifecycle`.

## Why
Integrators currently have to stitch together separate payroll, treasury, wallet, and contract event feeds themselves. A single ordered lifecycle stream gives dashboards, notifications, audit views, and reconciliation tools one reliable source of truth.

## Test plan
- [x] Unit tests in `packages/core/tests/lifecycle-event-aggregator.test.ts` covering: multi-source merge ordering, timestamp/sequence tie-breaking, ascending/descending order, source filtering, flat vs. grouped input, default summary generation, unique id assignment, grouping, and filtering.
- [ ] `npm test -w packages/core` (could not run in this sandbox — dependencies not installed)

Closes #254
