### PR TITLE
feat(core): add integration health report

### DIFF
--- a/packages/core/src/health/index.ts
+++ b/packages/core/src/health/index.ts
@@ -1,0 +1,10 @@
+export { generateIntegrationHealthReport } from "./report";
+export { INTEGRATION_HEALTH_SECTIONS, IntegrationHealthStatus } from "./types";
+export type {
+  IntegrationHealthProofInput,
+  IntegrationHealthReport,
+  IntegrationHealthReportInput,
+  IntegrationHealthSection,
+  IntegrationHealthSectionResult,
+  IntegrationHealthWallet,
+} from "./types";

--- a/packages/core/src/health/report.ts
+++ b/packages/core/src/health/report.ts
@@ -1,0 +1,322 @@
+import { validateConfig } from "../config";
+import type { ClientConfig, ConfigValidationResult } from "../config";
+import { detectEnvironment, NetworkCapabilityGuard } from "../env";
+import type { Capability, EnvironmentCapabilities, RuntimeEnvironment } from "../env";
+import { checkProofReadiness } from "../proof-readiness";
+import {
+  INTEGRATION_HEALTH_SECTIONS,
+  IntegrationHealthReport,
+  IntegrationHealthReportInput,
+  IntegrationHealthSection,
+  IntegrationHealthSectionResult,
+  IntegrationHealthStatus,
+  IntegrationHealthWallet,
+} from "./types";
+
+interface SafeHealthCopy {
+  message: string;
+  remediation?: string;
+}
+
+interface ConfigInspection {
+  usable: boolean;
+  result: ConfigValidationResult;
+}
+
+interface EnvironmentInspection {
+  usable: boolean;
+  value?: EnvironmentCapabilities;
+}
+
+const SAFE_HEALTH_COPY: Record<
+  IntegrationHealthSection,
+  Record<IntegrationHealthStatus, SafeHealthCopy>
+> = {
+  config: {
+    healthy: { message: "SDK configuration is ready." },
+    degraded: {
+      message: "SDK configuration has a non-blocking concern.",
+      remediation: "Review optional configuration values before payroll execution.",
+    },
+    failed: {
+      message: "SDK configuration is not ready.",
+      remediation: "Correct missing or invalid required SDK configuration values.",
+    },
+  },
+  network: {
+    healthy: { message: "Network readiness check passed." },
+    degraded: {
+      message: "Network readiness is degraded.",
+      remediation: "Review the selected network and RPC capability before execution.",
+    },
+    failed: {
+      message: "Network readiness check failed.",
+      remediation: "Select a valid RPC URL and a runtime with RPC capability.",
+    },
+  },
+  contracts: {
+    healthy: { message: "Contract configuration is ready." },
+    degraded: {
+      message: "Contract configuration has a non-blocking concern.",
+      remediation: "Review optional contract configuration for the selected network.",
+    },
+    failed: {
+      message: "Contract configuration is not ready.",
+      remediation: "Provide valid required Soroban contract identifiers.",
+    },
+  },
+  proofs: {
+    healthy: { message: "Proof generation prerequisites are ready." },
+    degraded: {
+      message: "Proof readiness has a non-blocking concern.",
+      remediation: "Use a proof-capable runtime before generating a proof.",
+    },
+    failed: {
+      message: "Proof generation prerequisites are not ready.",
+      remediation: "Correct proof settings, input shape, mode, and artifact locations.",
+    },
+  },
+  wallet: {
+    healthy: { message: "Wallet capability check passed." },
+    degraded: {
+      message: "Wallet capability is limited.",
+      remediation: "Use an available wallet adapter and connect it before wallet operations.",
+    },
+    failed: {
+      message: "Wallet capability check failed.",
+      remediation: "Provide a valid passive wallet capability view.",
+    },
+  },
+};
+
+const NETWORK_FIELDS = ["networkUrl", "network"] as const;
+const CONTRACT_FIELDS = ["contractId", "contractIds"] as const;
+const PROOF_FIELDS = ["proofConfig"] as const;
+const RUNTIME_ENVIRONMENTS = new Set<RuntimeEnvironment>(["browser", "worker", "node", "unknown"]);
+const CAPABILITIES = new Set<Capability>([
+  "wallet_connection",
+  "proof_generation",
+  "rpc_call",
+  "file_system",
+  "web_worker",
+  "localStorage",
+  "indexedDB",
+  "crypto.getRandomValues",
+  "wasm",
+  "fetch",
+]);
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function failedValidation(field: string): ConfigValidationResult {
+  return { isValid: false, errors: [{ field, message: "Invalid health report input." }] };
+}
+
+function inspectConfig(value: unknown): ConfigInspection {
+  if (!isRecord(value)) {
+    return { usable: false, result: failedValidation("config") };
+  }
+
+  try {
+    return { usable: true, result: validateConfig(value as Partial<ClientConfig>) };
+  } catch {
+    return { usable: false, result: failedValidation("config") };
+  }
+}
+
+function hasValidationError(inspection: ConfigInspection, fields: ReadonlyArray<string>): boolean {
+  if (!inspection.usable) return true;
+  return inspection.result.errors.some((error) =>
+    fields.some((field) => error.field === field || error.field.startsWith(`${field}.`))
+  );
+}
+
+function hasGeneralConfigError(inspection: ConfigInspection): boolean {
+  if (!inspection.usable) return true;
+  const sectionFields = [...NETWORK_FIELDS, ...CONTRACT_FIELDS, ...PROOF_FIELDS];
+  return inspection.result.errors.some(
+    (error) =>
+      !sectionFields.some((field) => error.field === field || error.field.startsWith(`${field}.`))
+  );
+}
+
+function isEnvironmentCapabilities(value: unknown): value is EnvironmentCapabilities {
+  if (!isRecord(value)) return false;
+  if (!RUNTIME_ENVIRONMENTS.has(value.environment as RuntimeEnvironment)) return false;
+  if (!(value.capabilities instanceof Set)) return false;
+  if (
+    typeof value.hasWalletSupport !== "boolean" ||
+    typeof value.hasWasm !== "boolean" ||
+    typeof value.hasCrypto !== "boolean"
+  ) {
+    return false;
+  }
+
+  try {
+    return Array.from(value.capabilities).every((capability) =>
+      CAPABILITIES.has(capability as Capability)
+    );
+  } catch {
+    return false;
+  }
+}
+
+function inspectEnvironment(value: unknown): EnvironmentInspection {
+  try {
+    const environment = value === undefined ? detectEnvironment() : value;
+    return isEnvironmentCapabilities(environment)
+      ? { usable: true, value: environment }
+      : { usable: false };
+  } catch {
+    return { usable: false };
+  }
+}
+
+function checkConfig(inspection: ConfigInspection): IntegrationHealthStatus {
+  return hasGeneralConfigError(inspection)
+    ? IntegrationHealthStatus.FAILED
+    : IntegrationHealthStatus.HEALTHY;
+}
+
+function checkNetwork(
+  config: ConfigInspection,
+  environment: EnvironmentInspection
+): IntegrationHealthStatus {
+  if (hasValidationError(config, NETWORK_FIELDS) || !environment.usable || !environment.value) {
+    return IntegrationHealthStatus.FAILED;
+  }
+
+  try {
+    const guard = new NetworkCapabilityGuard({ environment: environment.value });
+    return guard.canFetch().supported && guard.canPoll().supported
+      ? IntegrationHealthStatus.HEALTHY
+      : IntegrationHealthStatus.FAILED;
+  } catch {
+    return IntegrationHealthStatus.FAILED;
+  }
+}
+
+function checkContracts(config: ConfigInspection): IntegrationHealthStatus {
+  return hasValidationError(config, CONTRACT_FIELDS)
+    ? IntegrationHealthStatus.FAILED
+    : IntegrationHealthStatus.HEALTHY;
+}
+
+function checkProofs(
+  input: IntegrationHealthReportInput,
+  environment: EnvironmentInspection
+): IntegrationHealthStatus {
+  const proofConfig = input.config?.proofConfig;
+  if (!environment.usable || !environment.value || !isRecord(proofConfig)) {
+    return IntegrationHealthStatus.FAILED;
+  }
+  if (!isRecord(input.proof)) return IntegrationHealthStatus.FAILED;
+
+  try {
+    const readiness = checkProofReadiness(
+      {
+        proofConfig,
+        input: input.proof.input,
+        mode: input.proof.mode,
+      },
+      {
+        ...(input.proof.options ?? {}),
+        checkArtifactFiles: false,
+      }
+    );
+    if (!readiness.ready) return IntegrationHealthStatus.FAILED;
+
+    const hasWarning = readiness.checks.some((check) => check.status === "warn");
+    const guard = new NetworkCapabilityGuard({ environment: environment.value });
+    return hasWarning || !guard.canGenerateProof().supported
+      ? IntegrationHealthStatus.DEGRADED
+      : IntegrationHealthStatus.HEALTHY;
+  } catch {
+    return IntegrationHealthStatus.FAILED;
+  }
+}
+
+function checkWallet(
+  wallet: IntegrationHealthWallet | undefined,
+  environment: EnvironmentInspection
+): IntegrationHealthStatus {
+  if (!environment.usable || !environment.value) return IntegrationHealthStatus.FAILED;
+  if (wallet === undefined) return IntegrationHealthStatus.DEGRADED;
+
+  try {
+    if (typeof wallet.isAvailable !== "function" || typeof wallet.isConnected !== "boolean") {
+      return IntegrationHealthStatus.FAILED;
+    }
+    const available = wallet.isAvailable();
+    if (typeof available !== "boolean") return IntegrationHealthStatus.FAILED;
+    if (
+      !available ||
+      !environment.value.hasWalletSupport ||
+      !environment.value.capabilities.has("wallet_connection")
+    ) {
+      return IntegrationHealthStatus.DEGRADED;
+    }
+    return wallet.isConnected ? IntegrationHealthStatus.HEALTHY : IntegrationHealthStatus.DEGRADED;
+  } catch {
+    return IntegrationHealthStatus.FAILED;
+  }
+}
+
+function buildSection(
+  section: IntegrationHealthSection,
+  status: IntegrationHealthStatus
+): IntegrationHealthSectionResult {
+  const copy = SAFE_HEALTH_COPY[section][status];
+  return copy.remediation
+    ? { section, status, message: copy.message, remediation: copy.remediation }
+    : { section, status, message: copy.message };
+}
+
+function aggregateHealthStatus(
+  sections: ReadonlyArray<IntegrationHealthSectionResult>
+): IntegrationHealthStatus {
+  if (sections.some((section) => section.status === IntegrationHealthStatus.FAILED)) {
+    return IntegrationHealthStatus.FAILED;
+  }
+  if (sections.some((section) => section.status === IntegrationHealthStatus.DEGRADED)) {
+    return IntegrationHealthStatus.DEGRADED;
+  }
+  return IntegrationHealthStatus.HEALTHY;
+}
+
+/**
+ * Generates a deterministic, safe-to-log integration report from SDK-owned checks.
+ *
+ * The SDK only parses data, inspects runtime capabilities, runs proof readiness
+ * with local file probing disabled, calls `wallet.isAvailable()`, and reads
+ * `wallet.isConnected`. It never connects a wallet, signs or submits a
+ * transaction, calls a contract, generates a proof, opens an artifact, or makes
+ * a network request. The supplied wallet owns the behavior of its two permitted
+ * observations; consumers must keep those observations passive as required by
+ * {@link IntegrationHealthWallet}.
+ *
+ * Raw validation details, proof diagnostics, runtime values, wallet data, and
+ * thrown errors are discarded. Only fixed SDK copy enters the report.
+ */
+export function generateIntegrationHealthReport(
+  input: IntegrationHealthReportInput
+): IntegrationHealthReport {
+  const safeInput = isRecord(input) ? input : {};
+  const typedInput = safeInput as IntegrationHealthReportInput;
+  const config = inspectConfig(typedInput.config);
+  const environment = inspectEnvironment(typedInput.environment);
+  const statuses: Record<IntegrationHealthSection, IntegrationHealthStatus> = {
+    config: checkConfig(config),
+    network: checkNetwork(config, environment),
+    contracts: checkContracts(config),
+    proofs: checkProofs(typedInput, environment),
+    wallet: checkWallet(typedInput.wallet, environment),
+  };
+  const sections = INTEGRATION_HEALTH_SECTIONS.map((section) =>
+    buildSection(section, statuses[section])
+  );
+
+  return { status: aggregateHealthStatus(sections), sections };
+}

--- a/packages/core/src/health/types.ts
+++ b/packages/core/src/health/types.ts
@@ -1,0 +1,72 @@
+import type { ClientConfig } from "../config";
+import type { EnvironmentCapabilities } from "../env";
+import type { ProofReadinessInput, ProofReadinessOptions } from "../proof-readiness";
+import type { IWalletAdapter } from "../wallets";
+
+/** Stable section order used by every integration health report. */
+export const INTEGRATION_HEALTH_SECTIONS = [
+  "config",
+  "network",
+  "contracts",
+  "proofs",
+  "wallet",
+] as const;
+
+/** A diagnostic area covered by the integration health report. */
+export type IntegrationHealthSection = (typeof INTEGRATION_HEALTH_SECTIONS)[number];
+
+/** Supported outcomes for an individual section and the aggregate report. */
+export const IntegrationHealthStatus = {
+  HEALTHY: "healthy",
+  DEGRADED: "degraded",
+  FAILED: "failed",
+} as const;
+
+/** Health status derived from the fixed {@link IntegrationHealthStatus} values. */
+export type IntegrationHealthStatus =
+  (typeof IntegrationHealthStatus)[keyof typeof IntegrationHealthStatus];
+
+/**
+ * Proof data inspected by the health report.
+ *
+ * Artifact files are never opened by the health report, even if a caller tries
+ * to enable file probing through an untyped runtime value.
+ */
+export type IntegrationHealthProofInput = Omit<ProofReadinessInput, "proofConfig"> & {
+  options?: Omit<ProofReadinessOptions, "checkArtifactFiles">;
+};
+
+/** The only wallet observations the SDK-owned health check may perform. */
+export type IntegrationHealthWallet = Pick<IWalletAdapter, "isAvailable" | "isConnected">;
+
+/** Typed, data-oriented inputs for the SDK-owned integration diagnostics. */
+export interface IntegrationHealthReportInput {
+  /** SDK configuration, including network, contract, and proof-artifact settings. */
+  config?: Partial<ClientConfig>;
+  /** Pre-detected capabilities; defaults to SDK environment detection when omitted. */
+  environment?: EnvironmentCapabilities;
+  /** Proof input shape and mode. The proof configuration comes from `config.proofConfig`. */
+  proof?: IntegrationHealthProofInput;
+  /** Optional passive wallet capability view. */
+  wallet?: IntegrationHealthWallet;
+}
+
+/** Safe-to-log result for one integration area. */
+export interface IntegrationHealthSectionResult {
+  /** The integration area that was checked. */
+  section: IntegrationHealthSection;
+  /** The SDK-derived outcome of the check. */
+  status: IntegrationHealthStatus;
+  /** Fixed, non-sensitive description supplied by the SDK. */
+  message: string;
+  /** Fixed guidance for resolving a degraded or failed result. */
+  remediation?: string;
+}
+
+/** Aggregate, deterministic health report returned to SDK consumers. */
+export interface IntegrationHealthReport {
+  /** Worst status across all sections: failed, then degraded, then healthy. */
+  status: IntegrationHealthStatus;
+  /** Results in the stable config/network/contracts/proofs/wallet order. */
+  sections: ReadonlyArray<IntegrationHealthSectionResult>;
+}

--- a/packages/core/src/index.ts
+++ b/packages/core/src/index.ts
@@ -124,6 +124,9 @@ export * from "./sanity";
 // ── Proof Readiness Checker ─────────────────────────────────────────────────
 export * from "./proof-readiness";
 
+// ── Integration Health Report ───────────────────────────────────────────────
+export * from "./health";
+
 // ── Transaction Simulation ──────────────────────────────────────────────────
 export * from "./simulation";
 

--- a/packages/core/tests/health-report.test.ts
+++ b/packages/core/tests/health-report.test.ts
@@ -1,0 +1,226 @@
+import type { EnvironmentCapabilities } from "../src/env";
+import {
+  generateIntegrationHealthReport,
+  INTEGRATION_HEALTH_SECTIONS,
+  IntegrationHealthReportInput,
+  IntegrationHealthStatus,
+} from "../src/health";
+
+const VALID_CONTRACT_ID = "CAKZGMMMJOHMSZ5V3DYKCUDNTIWBG57MAMFJDSVICNWUNVXLX6EZN3NC";
+
+function healthyEnvironment(): EnvironmentCapabilities {
+  return {
+    environment: "browser",
+    capabilities: new Set([
+      "fetch",
+      "rpc_call",
+      "wallet_connection",
+      "proof_generation",
+      "wasm",
+      "crypto.getRandomValues",
+    ]),
+    hasWalletSupport: true,
+    hasWasm: true,
+    hasCrypto: true,
+  };
+}
+
+function healthyInput(
+  overrides: Partial<IntegrationHealthReportInput> = {}
+): IntegrationHealthReportInput {
+  return {
+    config: {
+      networkUrl: "https://soroban-testnet.stellar.org",
+      network: "testnet",
+      contractId: VALID_CONTRACT_ID,
+      proofConfig: {
+        wasmUrl: "https://artifacts.example/circuit.wasm",
+        zkeyUrl: "https://artifacts.example/circuit.zkey",
+      },
+    },
+    environment: healthyEnvironment(),
+    proof: { input: {}, mode: "groth16" },
+    wallet: { isAvailable: jest.fn(() => true), isConnected: true },
+    ...overrides,
+  };
+}
+
+function statusFor(
+  report: ReturnType<typeof generateIntegrationHealthReport>,
+  section: (typeof INTEGRATION_HEALTH_SECTIONS)[number]
+): string | undefined {
+  return report.sections.find((result) => result.section === section)?.status;
+}
+
+describe("generateIntegrationHealthReport", () => {
+  it("runs all five SDK-owned checks and reports a healthy integration", () => {
+    const report = generateIntegrationHealthReport(healthyInput());
+
+    expect(report.status).toBe(IntegrationHealthStatus.HEALTHY);
+    expect(report.sections.map((section) => section.section)).toEqual(INTEGRATION_HEALTH_SECTIONS);
+    expect(report.sections.every((section) => section.status === "healthy")).toBe(true);
+  });
+
+  it("reports degraded when a supported wallet is available but disconnected", () => {
+    const wallet = { isAvailable: jest.fn(() => true), isConnected: false };
+    const report = generateIntegrationHealthReport(healthyInput({ wallet }));
+
+    expect(report.status).toBe(IntegrationHealthStatus.DEGRADED);
+    expect(statusFor(report, "wallet")).toBe(IntegrationHealthStatus.DEGRADED);
+    expect(wallet.isAvailable).toHaveBeenCalledTimes(1);
+  });
+
+  it("maps unavailable runtime capabilities to fixed section outcomes", () => {
+    const environment: EnvironmentCapabilities = {
+      environment: "worker",
+      capabilities: new Set(["wasm", "crypto.getRandomValues"]),
+      hasWalletSupport: false,
+      hasWasm: true,
+      hasCrypto: true,
+    };
+    const report = generateIntegrationHealthReport(healthyInput({ environment }));
+
+    expect(report.status).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "network")).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "proofs")).toBe(IntegrationHealthStatus.DEGRADED);
+    expect(statusFor(report, "wallet")).toBe(IntegrationHealthStatus.DEGRADED);
+  });
+
+  it("maps malformed config, URL, contract, and proof inputs to safe failures", () => {
+    const report = generateIntegrationHealthReport({
+      ...healthyInput(),
+      config: {
+        networkUrl: "credential-secret invalid-url",
+        contractId: "private-contract-secret",
+        proofConfig: { wasmUrl: "proof-secret" } as never,
+        featureFlags: { "private-feature-secret": "yes" as never },
+      },
+      proof: { input: { salary: "private-payroll-secret" }, mode: "unknown-secret-mode" },
+    });
+
+    expect(report.status).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "config")).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "network")).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "contracts")).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "proofs")).toBe(IntegrationHealthStatus.FAILED);
+    expect(report.sections.filter((section) => section.status === "failed")).toHaveLength(4);
+    expect(report.sections.find((section) => section.section === "contracts")?.remediation).toBe(
+      "Provide valid required Soroban contract identifiers."
+    );
+  });
+
+  it("never exposes comprehensive sentinels from any high-level input", () => {
+    const sentinels = [
+      "URL_USER_SECRET",
+      "URL_TOKEN_SECRET",
+      "ADMIN_KEY_SECRET",
+      "CONTRACT_KEY_SECRET",
+      "CONTRACT_VALUE_SECRET",
+      "ARTIFACT_SECRET",
+      "PAYROLL_INPUT_SECRET",
+      "PROOF_FIELD_SECRET",
+      "WALLET_THROW_SECRET",
+    ];
+    const report = generateIntegrationHealthReport({
+      config: {
+        networkUrl: "https://URL_USER_SECRET@rpc.example/?token=URL_TOKEN_SECRET",
+        contractIds: { CONTRACT_KEY_SECRET: "CONTRACT_VALUE_SECRET" },
+        adminKey: "ADMIN_KEY_SECRET",
+        proofConfig: {
+          wasmUrl: "https://ARTIFACT_SECRET@artifacts.example/circuit.wasm",
+          zkeyUrl: "https://artifacts.example/circuit.zkey?token=ARTIFACT_SECRET",
+        },
+      },
+      environment: healthyEnvironment(),
+      proof: {
+        input: {
+          salary: "PAYROLL_INPUT_SECRET",
+          recipient: "PROOF_FIELD_SECRET",
+        },
+        options: {
+          requiredInputFields: [{ name: "PROOF_FIELD_SECRET", type: "bigint" }],
+        },
+      },
+      wallet: {
+        isAvailable: () => {
+          throw new Error("WALLET_THROW_SECRET");
+        },
+        isConnected: false,
+      },
+    });
+
+    const serialized = JSON.stringify(report);
+    for (const sentinel of sentinels) expect(serialized).not.toContain(sentinel);
+    expect(serialized).not.toContain("Error");
+  });
+
+  it("maps invalid runtime inputs to generic failures without leaking values", () => {
+    const runtimeSecret = "INVALID_RUNTIME_SECRET";
+    const input = healthyInput({
+      environment: {
+        environment: runtimeSecret,
+        capabilities: ["rpc_call", runtimeSecret],
+        hasWalletSupport: runtimeSecret,
+        hasWasm: true,
+        hasCrypto: true,
+      } as never,
+    });
+    const report = generateIntegrationHealthReport(input);
+
+    expect(report.status).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "network")).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "proofs")).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "wallet")).toBe(IntegrationHealthStatus.FAILED);
+    expect(JSON.stringify(report)).not.toContain(runtimeSecret);
+  });
+
+  it("only observes wallet availability and connection state", () => {
+    const wallet = {
+      isAvailable: jest.fn(() => true),
+      isConnected: true,
+      connect: jest.fn(),
+      signTransaction: jest.fn(),
+      signAndSubmitTransaction: jest.fn(),
+      disconnect: jest.fn(),
+    };
+    const originalFetchDescriptor = Object.getOwnPropertyDescriptor(globalThis, "fetch");
+    const fetchDouble = jest.fn();
+    Object.defineProperty(globalThis, "fetch", {
+      configurable: true,
+      writable: true,
+      value: fetchDouble,
+    });
+
+    try {
+      const report = generateIntegrationHealthReport(healthyInput({ wallet }));
+
+      expect(report.status).toBe(IntegrationHealthStatus.HEALTHY);
+      expect(wallet.isAvailable).toHaveBeenCalledTimes(1);
+      expect(wallet.connect).not.toHaveBeenCalled();
+      expect(wallet.signTransaction).not.toHaveBeenCalled();
+      expect(wallet.signAndSubmitTransaction).not.toHaveBeenCalled();
+      expect(wallet.disconnect).not.toHaveBeenCalled();
+      expect(fetchDouble).not.toHaveBeenCalled();
+    } finally {
+      if (originalFetchDescriptor) {
+        Object.defineProperty(globalThis, "fetch", originalFetchDescriptor);
+      } else {
+        delete (globalThis as { fetch?: typeof fetch }).fetch;
+      }
+    }
+  });
+
+  it("uses fixed failures for invalid wallet runtime values", () => {
+    const report = generateIntegrationHealthReport(
+      healthyInput({
+        wallet: {
+          isAvailable: () => "yes",
+          isConnected: "connected",
+        } as never,
+      })
+    );
+
+    expect(report.status).toBe(IntegrationHealthStatus.FAILED);
+    expect(statusFor(report, "wallet")).toBe(IntegrationHealthStatus.FAILED);
+  });
+});


### PR DESCRIPTION
## Summary

Adds a public SDK integration-health helper that reports readiness across configuration, network, contracts, proofs, and wallet capability before payroll execution.

## Changes

- define typed health sections, statuses, report input, and result shapes;
- generate deterministic healthy/degraded/failed outcomes using existing SDK-owned validators and capability guards;
- return only fixed safe remediation copy, discarding raw validation details, proof inputs, wallet data, runtime values, and thrown errors;
- keep diagnostics passive: no network request, wallet connection/signing, proof generation, artifact read, contract call, payroll execution, or submission;
- export the health module and add focused Node/browser coverage for success, degradation, failure, privacy sentinels, passive behavior, and fetch restoration.

## Testing / Verification

- `npm ci --ignore-scripts` — pass
- exact five-path Prettier check — pass
- targeted package-aware ESLint — pass
- focused Node Jest — 8/8 pass
- focused browser Jest — 8/8 pass
- full core Jest — 1,385/1,385 executed tests pass; seven existing suites do not compile because of unchanged baseline errors in `WorkerProofGenerator.ts:248` and `tests/config.test.ts:13`
- package typecheck/build reproduce those same two unchanged baseline errors

Closes #264